### PR TITLE
fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,6 @@ USER 65532:65532
 
 COPY grafonnet-lib/grafonnet/ /opt/jsonnet/grafonnet
 
-COPY bin/manager /usr/local/bin/grafana-operator
+COPY manager manager
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["./manager"]


### PR DESCRIPTION
## Description
Fixes
```
STEP 18: COPY bin/manager /usr/local/bin/grafana-operator
Error: error building at STEP "COPY bin/manager /usr/local/bin/grafana-operator": error adding sources [/home/hstefans/go/src/github.com/integr8ly/grafana-operator/bin/manager]: error checking on source /home/hstefans/go/src/github.com/integr8ly/grafana-operator/bin/manager under "/home/hstefans/go/src/github.com/integr8ly/grafana-operator": copier: stat: "/bin/manager": no such file or directory
```



## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
run `podman build . ` , the command should result in a successful image build