### PR TITLE
fix: use correct service dns name

### DIFF
--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -262,7 +262,7 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 
 	// Otherwise rely on the service
 	if state.GrafanaService != nil {
-		return fmt.Sprintf("http://%v:%d", state.GrafanaService.Name,
+		return fmt.Sprintf("%v.%v.svc.cluster.local:%d", state.GrafanaService.Name, cr.Namespace,
 			servicePort), nil
 	}
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,8 +21,6 @@ spec:
           ports:
             - containerPort: 60000
               name: metrics
-          command:
-            - grafana-operator
           imagePullPolicy: Always
           env:
             - name: TEMPLATE_PATH


### PR DESCRIPTION
## Description

Fixes an issue where the constructed service DNS name was invalid when using the `preferService` option.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Verification steps

1. Create a custom image and deploy the Operator to a cluster using that image.
2. Deploy grafana makeing sure that `client.preferService` is set to `true` in the spec.
3. Create dashboards and make sure they can be imported and deleted.

