### PR TITLE
fix nil pointer exception on cr.Spec.Deployment

### DIFF
--- a/controllers/model/grafanaDeployment.go
+++ b/controllers/model/grafanaDeployment.go
@@ -442,7 +442,7 @@ func getContainers(cr *v1alpha1.Grafana, configHash, dsHash string) []v13.Contai
 			Value: dsHash,
 		},
 	}
-	if cr.Spec.Deployment.HttpProxy != nil && cr.Spec.Deployment.HttpProxy.Enabled {
+	if cr.Spec.Deployment != nil && cr.Spec.Deployment.HttpProxy != nil && cr.Spec.Deployment.HttpProxy.Enabled {
 		envVars = append(envVars, v13.EnvVar{
 			Name:  "HTTP_PROXY",
 			Value: cr.Spec.Deployment.HttpProxy.URL,
@@ -520,7 +520,7 @@ func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 		},
 	}
 
-	if cr.Spec.Deployment.HttpProxy != nil && cr.Spec.Deployment.HttpProxy.Enabled {
+	if cr.Spec.Deployment != nil && cr.Spec.Deployment.HttpProxy != nil && cr.Spec.Deployment.HttpProxy.Enabled {
 		envVars = append(envVars, v13.EnvVar{
 			Name:  "HTTP_PROXY",
 			Value: cr.Spec.Deployment.HttpProxy.URL,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
- Fixes a missed nil check on the Deployment struct when attempting to access httpProxy config.

```
E0706 21:20:02.234098  916414 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 655 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1648f40, 0x23c4850)
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:48 +0x86
panic(0x1648f40, 0x23c4850)
        /usr/lib/golang/src/runtime/panic.go:965 +0x1b9
github.com/integr8ly/grafana-operator/controllers/model.getInitContainers(0xc000261000, 0x0, 0x0, 0x8, 0xc0006593a8, 0x0)
        /home/hstefans/go/src/github.com/grafana-operator/grafana-operator/controllers/model/grafanaDeployment.go:523 +0x121
github.com/integr8ly/grafana-operator/controllers/model.getDeploymentSpec(0xc000261000, 0xc00074ec90, 0xc000786500, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/hstefans/go/src/github.com/grafana-operator/grafana-operator/controllers/model/grafanaDeployment.go:570 +0x32e
github.com/integr8ly/grafana-operator/controllers/model.GrafanaDeploymentReconciled(0xc000261000, 0xc000221b00, 0xc000786500, 0x40, 0x0, 0x0, 0x0, 0x0, 0xc67178f2bef9a3f7)
        /home/hstefans/go/src/github.com/grafana-operator/grafana-operator/controllers/model/grafanaDeployment.go:600 +0xbe
github.com/integr8ly/grafana-operator/controllers/grafana.(*GrafanaReconciler).getGrafanaDeploymentDesiredState(0xc000557b38, 0xc000557bb0, 0xc000261000, 0x4, 0x5)
        /home/hstefans/go/src/github.com/grafana-operator/grafana-operator/controllers/grafana/grafana_reconciler.go:274 +0x258
github.com/integr8ly/grafana-operator/controllers/grafana.(*GrafanaReconciler).Reconcile(0xc000557b38, 0xc000557bb0, 0xc000261000, 0xc000261000, 0x1a35118, 0xc0001133b0)
        /home/hstefans/go/src/github.com/grafana-operator/grafana-operator/controllers/grafana/grafana_reconciler.go:53 +0x4e5
github.com/integr8ly/grafana-operator/controllers/grafana.(*ReconcileGrafana).Reconcile(0xc00032daa0, 0x1a23118, 0xc00074e1e0, 0xc0004be949, 0x7, 0xc0004be930, 0xf, 0xc00074e1e0, 0xc000032000, 0x16d1360, ...)
        /home/hstefans/go/src/github.com/grafana-operator/grafana-operator/controllers/grafana/grafana_controller.go:181 +0x2b5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00043b220, 0x1a23070, 0xc0007a07c0, 0x1698d20, 0xc0007c6000)
        /home/hstefans/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00043b220, 0x1a23070, 0xc0007a07c0, 0x200c000141100)
        /home/hstefans/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2(0x1a23070, 0xc0007a07c0)
        /home/hstefans/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:216 +0x4a
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185 +0x37
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0005bef50)
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000557f50, 0x19f2120, 0xc00074e150, 0xc0007a0701, 0xc000050de0)
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0005bef50, 0x3b9aca00, 0x0, 0xc0006ba001, 0xc000050de0)
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext(0x1a23070, 0xc0007a07c0, 0xc0004341d0, 0x3b9aca00, 0x0, 0xc0004d1101)
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185 +0xa6
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(0x1a23070, 0xc0007a07c0, 0xc0004341d0, 0x3b9aca00)
        /home/hstefans/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:99 +0x57
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /home/hstefans/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:213 +0x40d
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x13e3e01]

```

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->

- Check out master and run `make generate && make install && oc apply -f deploy/examples/Grafana.yaml && make run`
  - See error as above
- Check out this branch and re-run the operator,
  - Check for nil pointer    
