### PR TITLE
Add missing kubebuilder rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,9 +7,36 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - integreatly.org
+  - ""
   resources:
-  - grafanadashboards
+  - configmaps
+  - persistentvolumeclaims
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - deployments/finalizers
   verbs:
   - create
   - delete
@@ -21,9 +48,15 @@ rules:
 - apiGroups:
   - integreatly.org
   resources:
-  - grafanadashboards/finalizers
+  - grafanadashboards
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
+  - watch
 - apiGroups:
   - integreatly.org
   resources:
@@ -47,14 +80,53 @@ rules:
 - apiGroups:
   - integreatly.org
   resources:
-  - grafanadatasources/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - integreatly.org
-  resources:
   - grafanadatasources/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafanas
+  - grafanas/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafanas/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -34,6 +34,14 @@ const DefaultClientTimeoutSeconds = 5
 
 var log = logf.Log.WithName(ControllerName)
 
+// +kubebuilder:rbac:groups=integreatly.org,resources=grafanas;grafanas/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=integreatly.org,resources=grafanas/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=extensions;apps,resources=deployments;deployments/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups="",resources=configmaps;secrets;serviceaccounts;services;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReconcileGrafana) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/grafanadashboard/grafanadashboard_controller.go
+++ b/controllers/grafanadashboard/grafanadashboard_controller.go
@@ -72,7 +72,6 @@ type GrafanaDashboardReconciler struct {
 
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/grafanadatasource/datasource_controller.go
+++ b/controllers/grafanadatasource/datasource_controller.go
@@ -63,7 +63,6 @@ var _ reconcile.Reconciler = &GrafanaDatasourceReconciler{}
 
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadatasources,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadatasources/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=integreatly.org,resources=grafanadatasources/finalizers,verbs=update
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile


### PR DESCRIPTION
## Description
In the master branch there a bunch of missing roles that doesn't get generated.

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
- #465 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
Follow https://github.com/grafana-operator/grafana-operator/blob/master/documentation/develop.md#kind-load-docker-image

```shell
kubectl apply -f deploy/examples/Grafana.yaml
```

You shouldn't see any errors in the logs about missing access to perform certain tasks.

Note that I didn't add a bunch off access defined in the old rbac, https://github.com/grafana-operator/grafana-operator/blob/master/deploy/role.yaml

For example I don't think we need access to perform tasks against `pods & endpoints`.
I don't know to what degree you should be able to patch/update a event as a operator, naturally for me it feels like it should be only create, get, list.

We do not need access to look at `replicasets, statefulsets, daemonsets` I'm unsure about `deployments/finalizers`, would love some feedback on that.

In OCP routes there is mention of a resource called `routes/custom-host` I looked in the routes github repo but I can't find this resource type, but I can't say I looked allot. Is this some thing from OCP3? Is it still in use?

I have only tested that deploy/examples/Grafana.yaml  looks okay, would be great to get some help to verify some other parts.

Please look through the rbac rules generated and see if you thing if soemthing should be added/deleted.