### PR TITLE
Check manifest generation at PR

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -43,6 +43,26 @@ jobs:
             exit 1
           fi
 
+  manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2.3.4
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
+      - name: Run manifests
+        run: |
+          make manifests
+      - name: Check if working tree is dirty
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            git diff
+            echo 'run make manifests and commit changes'
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
This way if the developer have forgotten to check in the latest
manifest files it will be cought.
And the reviewers don't have to guess

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Devops
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
Create a PR that would generate manifests changes but forget to run make manifests.