### PR TITLE
Recreate dashboards deleted via Grafana console

### DIFF
--- a/config/crd/bases/integreatly.org_grafanas.yaml
+++ b/config/crd/bases/integreatly.org_grafanas.yaml
@@ -451,6 +451,21 @@ spec:
                       level:
                         type: string
                     type: object
+                  log.frontend:
+                    properties:
+                      custom_endpoint:
+                        type: string
+                      enabled:
+                        type: boolean
+                      log_endpoint_burst_limit:
+                        type: integer
+                      log_endpoint_requests_per_second_limit:
+                        type: integer
+                      sample_rate:
+                        type: string
+                      sentry_dsn:
+                        type: string
+                    type: object
                   metrics:
                     properties:
                       basic_auth_password:

--- a/controllers/grafanadashboard/dashboard_pipeline.go
+++ b/controllers/grafanadashboard/dashboard_pipeline.go
@@ -29,7 +29,7 @@ const (
 )
 
 type DashboardPipeline interface {
-	ProcessDashboard(knownHash string, folderId *int64, folderName string) ([]byte, error)
+	ProcessDashboard(knownHash string, folderId *int64, folderName string, forceRecreate bool) ([]byte, error)
 	NewHash() string
 }
 
@@ -53,7 +53,7 @@ func NewDashboardPipeline(client client.Client, dashboard *v1alpha1.GrafanaDashb
 	}
 }
 
-func (r *DashboardPipelineImpl) ProcessDashboard(knownHash string, folderId *int64, folderName string) ([]byte, error) {
+func (r *DashboardPipelineImpl) ProcessDashboard(knownHash string, folderId *int64, folderName string, forceRecreate bool) ([]byte, error) {
 	err := r.obtainJson()
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (r *DashboardPipelineImpl) ProcessDashboard(knownHash string, folderId *int
 
 	// Dashboard unchanged?
 	hash := r.Dashboard.Hash()
-	if hash == knownHash {
+	if hash == knownHash && !forceRecreate {
 		r.Hash = knownHash
 		return nil, nil
 	}

--- a/controllers/grafanadashboard/grafana_client.go
+++ b/controllers/grafanadashboard/grafana_client.go
@@ -50,6 +50,24 @@ type GrafanaFolderRequest struct {
 	Title string `json:"title"`
 }
 
+type GrafanaDashboardResponse struct {
+	Meta      *GrafanaDashboardMeta `json:"meta,omitempty"`
+	Dashboard *GrafanaDashboard     `json:"dashboard,omitempty"`
+}
+
+type GrafanaDashboard struct {
+	ID      *uint   `json:"id"`
+	UID     *string `json:"uid"`
+	Title   *string `json:"title"`
+	Version *uint   `json:"version"`
+}
+
+type GrafanaDashboardMeta struct {
+	FolderID    *uint   `json:"folderId"`
+	FolderTitle *string `json:"folderTitle"`
+	Version     *uint   `json:"version"`
+}
+
 type GrafanaFolderResponse struct {
 	ID    *int64 `json:"id"`
 	Title string `json:"title"`
@@ -62,6 +80,7 @@ type GrafanaClient interface {
 	CreateOrUpdateFolder(folderName string) (GrafanaFolderResponse, error)
 	DeleteFolder(folderID *int64) error
 	SafeToDelete(dashboards []*v1alpha1.GrafanaDashboardRef, folderID *int64) bool
+	GetDashboard(UID string) (GrafanaDashboardResponse, error)
 }
 
 type GrafanaClientImpl struct {
@@ -89,6 +108,48 @@ func NewGrafanaClient(url, user, password string, transport *http.Transport, tim
 		password: password,
 		client:   client,
 	}
+}
+
+func (r *GrafanaClientImpl) GetDashboard(UID string) (GrafanaDashboardResponse, error) {
+	rawURL := fmt.Sprintf(DeleteDashboardByUIDUrl, r.url, UID)
+	response := newDashboardResponse()
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return response, err
+	}
+
+	parsed.User = url.UserPassword(r.user, r.password)
+	req, err := http.NewRequest("GET", parsed.String(), nil)
+
+	if err != nil {
+		return response, err
+	}
+
+	setHeaders(req)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return response, err
+	} else if resp.StatusCode != 200 {
+		return response, fmt.Errorf(
+			"error searching for dashboard, expected status 200 but got %v",
+			resp.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.Unmarshal(data, &response)
+
+	return response, err
 }
 
 func (r *GrafanaClientImpl) getAllFolders() ([]GrafanaFolderResponse, error) {
@@ -329,6 +390,24 @@ func newResponse() GrafanaResponse {
 		Status:  &status,
 		UID:     &uid,
 		URL:     &url,
+	}
+}
+
+func newDashboardResponse() GrafanaDashboardResponse {
+	var id uint = 0
+	var version uint = 0
+	var uid string
+	var title string
+
+	dashboard := GrafanaDashboard{
+		ID:      &id,
+		UID:     &uid,
+		Version: &version,
+		Title:   &title,
+	}
+
+	return GrafanaDashboardResponse{
+		Dashboard: &dashboard,
 	}
 }
 


### PR DESCRIPTION
## Description
Dashboards delete via the Grafana console will still exist as CRs and won't be recreated. They should be recreate if deleete this way. The correct way to delete a dashboard is to delete the CR.

## Relevant issues/tickets
https://github.com/grafana-operator/grafana-operator/issues/432

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

1. Create a grafanadashboard CR
2. Log into the Grafana console
3. Delete the dashboard from Dashboard settings in the console
4. Wait for a periodic reconcile
5. Check in the Grafana console that the dashboard has been recreated