### PR TITLE
Add `role_attribute_strict` flag in generic/okta oauth config

### DIFF
--- a/api/integreatly/v1alpha1/grafana_types.go
+++ b/api/integreatly/v1alpha1/grafana_types.go
@@ -359,6 +359,7 @@ type GrafanaConfigAuthGenericOauth struct {
 	ApiUrl                string `json:"api_url,omitempty" ini:"api_url,omitempty"`
 	AllowedDomains        string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
 	RoleAttributePath     string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	RoleAttributeStrict   *bool  `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
 	EmailAttributePath    string `json:"email_attribute_path,omitempty" ini:"email_attribute_path,omitempty"`
 	TLSSkipVerifyInsecure *bool  `json:"tls_skip_verify_insecure,omitempty" ini:"tls_skip_verify_insecure,omitempty"`
 	TLSClientCert         string `json:"tls_client_cert,omitempty" ini:"tls_client_cert,omitempty"`
@@ -367,18 +368,19 @@ type GrafanaConfigAuthGenericOauth struct {
 }
 
 type GrafanaConfigAuthOkta struct {
-	Enabled           *bool  `json:"enabled,omitempty" ini:"enabled"`
-	Name              string `json:"name,omitempty" ini:"name,omitempty"`
-	AllowSignUp       *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
-	ClientId          string `json:"client_id,omitempty" ini:"client_id,omitempty"`
-	ClientSecret      string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
-	Scopes            string `json:"scopes,omitempty" ini:"scopes,omitempty"`
-	AuthUrl           string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
-	TokenUrl          string `json:"token_url,omitempty" ini:"token_url,omitempty"`
-	ApiUrl            string `json:"api_url,omitempty" ini:"api_url,omitempty"`
-	AllowedDomains    string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
-	AllowedGroups     string `json:"allowed_groups,omitempty" ini:"allowed_groups,omitempty"`
-	RoleAttributePath string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	Enabled             *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Name                string `json:"name,omitempty" ini:"name,omitempty"`
+	AllowSignUp         *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
+	ClientId            string `json:"client_id,omitempty" ini:"client_id,omitempty"`
+	ClientSecret        string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
+	Scopes              string `json:"scopes,omitempty" ini:"scopes,omitempty"`
+	AuthUrl             string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
+	TokenUrl            string `json:"token_url,omitempty" ini:"token_url,omitempty"`
+	ApiUrl              string `json:"api_url,omitempty" ini:"api_url,omitempty"`
+	AllowedDomains      string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
+	AllowedGroups       string `json:"allowed_groups,omitempty" ini:"allowed_groups,omitempty"`
+	RoleAttributePath   string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	RoleAttributeStrict *bool  `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
 }
 
 type GrafanaConfigAuthLdap struct {

--- a/api/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/api/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -477,6 +477,11 @@ func (in *GrafanaConfigAuthGenericOauth) DeepCopyInto(out *GrafanaConfigAuthGene
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RoleAttributeStrict != nil {
+		in, out := &in.RoleAttributeStrict, &out.RoleAttributeStrict
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TLSSkipVerifyInsecure != nil {
 		in, out := &in.TLSSkipVerifyInsecure, &out.TLSSkipVerifyInsecure
 		*out = new(bool)
@@ -604,6 +609,11 @@ func (in *GrafanaConfigAuthOkta) DeepCopyInto(out *GrafanaConfigAuthOkta) {
 	}
 	if in.AllowSignUp != nil {
 		in, out := &in.AllowSignUp, &out.AllowSignUp
+		*out = new(bool)
+		**out = **in
+	}
+	if in.RoleAttributeStrict != nil {
+		in, out := &in.RoleAttributeStrict, &out.RoleAttributeStrict
 		*out = new(bool)
 		**out = **in
 	}

--- a/config/crd/bases/integreatly.org_grafanas.yaml
+++ b/config/crd/bases/integreatly.org_grafanas.yaml
@@ -159,6 +159,8 @@ spec:
                         type: boolean
                       role_attribute_path:
                         type: string
+                      role_attribute_strict:
+                        type: boolean
                       scopes:
                         type: string
                       tls_client_ca:
@@ -266,6 +268,8 @@ spec:
                         type: string
                       role_attribute_path:
                         type: string
+                      role_attribute_strict:
+                        type: boolean
                       scopes:
                         type: string
                       token_url:

--- a/controllers/config/grafanaIni.go
+++ b/controllers/config/grafanaIni.go
@@ -486,6 +486,7 @@ func (i *GrafanaIni) cfgAuthGenericOauth(config map[string][]string) map[string]
 	items = appendStr(items, "api_url", i.cfg.AuthGenericOauth.ApiUrl)
 	items = appendStr(items, "allowed_domains", i.cfg.AuthGenericOauth.AllowedDomains)
 	items = appendStr(items, "role_attribute_path", i.cfg.AuthGenericOauth.RoleAttributePath)
+	items = appendBool(items, "role_attribute_strict", i.cfg.AuthGenericOauth.RoleAttributeStrict)
 	items = appendStr(items, "email_attribute_path", i.cfg.AuthGenericOauth.EmailAttributePath)
 	items = appendBool(items, "tls_skip_verify_insecure", i.cfg.AuthGenericOauth.TLSSkipVerifyInsecure)
 	items = appendStr(items, "tls_client_cert", i.cfg.AuthGenericOauth.TLSClientCert)


### PR DESCRIPTION
## Description
Add `role_attribute_strict` bool flag in the generic and okta oauth configs.
This was added in upstream grafana in the following PR: https://github.com/grafana/grafana/pull/28021

## Relevant issues/tickets
Resolves https://github.com/grafana-operator/grafana-operator/issues/498

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
1. Deploy Operator
2. Deploy Grafana
3. Add the following in grafana resource
```yaml
config:
    auth.generic_oauth:
      enabled: true
      role_attribute_strict: true
```

4. The created grafana container should have a `grafana.ini` with the following string `role_attribute_strict: true`
