### PR TITLE
fix ing example

### DIFF
--- a/deploy/examples/GrafanaWithIngressHost.yaml
+++ b/deploy/examples/GrafanaWithIngressHost.yaml
@@ -6,6 +6,8 @@ spec:
   ingress:
     enabled: True
     hostname: "grafana.apps.127.0.0.1.nip.io"
+    path: /
+    pathType: Prefix
   config:
     log:
       mode: "console"


### PR DESCRIPTION

## Description
An error will be reported if the current example is used.
```
Ingress.extensions "grafana-ingress" is invalid:
    spec.rules[0].http.paths[0].pathType: Required value: pathType must be
    specified
```

## Relevant issues/tickets
none

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ x ] Verified independently on a cluster by reviewer

## Verification steps
```
kubectl apply -f deploy/examples/GrafanaWithIngressHost.yaml
```
