### PR TITLE
Backport 558b175a119ac3fc7ab70b94b1ce8598ea52d4d9

### DIFF
--- a/deploy/crds/Grafana.yaml
+++ b/deploy/crds/Grafana.yaml
@@ -130,6 +130,57 @@ spec:
                 skipCreateAdminAccount:
                   type: boolean
                   description: Disable creating a random admin user
+                strategy:
+                  description: DeploymentStrategy describes how to replace existing
+                    pods with new ones.
+                  properties:
+                    rollingUpdate:
+                      description: 'Rolling update config params. Present only if
+                        DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                        this to follow our convention for oneOf, whatever we decide
+                        it to be.'
+                      properties:
+                        maxSurge:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be scheduled
+                            above the desired number of pods. Value can be an absolute
+                            number (ex: 5) or a percentage of desired pods (ex:
+                            10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                            number is calculated from percentage by rounding up.
+                            Defaults to 25%. Example: when this is set to 30%, the
+                            new ReplicaSet can be scaled up immediately when the
+                            rolling update starts, such that the total number of
+                            old and new pods do not exceed 130% of desired pods.
+                            Once old pods have been killed, new ReplicaSet can be
+                            scaled up further, ensuring that total number of pods
+                            running at any time during the update is at most 130%
+                            of desired pods.'
+                          x-kubernetes-int-or-string: true
+                        maxUnavailable:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be unavailable
+                            during the update. Value can be an absolute number (ex:
+                            5) or a percentage of desired pods (ex: 10%). Absolute
+                            number is calculated from percentage by rounding down.
+                            This can not be 0 if MaxSurge is 0. Defaults to 25%.
+                            Example: when this is set to 30%, the old ReplicaSet
+                            can be scaled down to 70% of desired pods immediately
+                            when the rolling update starts. Once new pods are ready,
+                            old ReplicaSet can be scaled down further, followed
+                            by scaling up the new ReplicaSet, ensuring that the
+                            total number of pods available at all times during the
+                            update is at least 70% of desired pods.'
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type:
+                      description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                        Default is RollingUpdate.
+                      type: string
+                  type: object
                 priorityClassName:
                   type: string
                   description: Pod priority class name

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -325,6 +325,9 @@ spec:
     extraVolumes: <array>           # Append extra volumes to the Grafana deployment
     ...
     extraVolumeMounts: <array>      # Append extra volume mounts
+    ...
+    strategy:                       # Optional. The DeploymentStrategy to set for the Grafana deployment. Defaults to 25%/25% RollingUpdate if unset.
+    ...
 ```
 
 NOTE: Some key's are common to both in securityContext and containerSecurityContext, in that case

--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	v12 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,21 +93,22 @@ type GrafanaServiceAccount struct {
 
 // GrafanaDeployment provides a means to configure the deployment
 type GrafanaDeployment struct {
-	Annotations                   map[string]string      `json:"annotations,omitempty"`
-	Labels                        map[string]string      `json:"labels,omitempty"`
-	Replicas                      int32                  `json:"replicas"`
-	NodeSelector                  map[string]string      `json:"nodeSelector,omitempty"`
-	Tolerations                   []v1.Toleration        `json:"tolerations,omitempty"`
-	Affinity                      *v1.Affinity           `json:"affinity,omitempty"`
-	SecurityContext               *v1.PodSecurityContext `json:"securityContext,omitempty"`
-	ContainerSecurityContext      *v1.SecurityContext    `json:"containerSecurityContext,omitempty"`
-	TerminationGracePeriodSeconds int64                  `json:"terminationGracePeriodSeconds"`
-	EnvFrom                       []v1.EnvFromSource     `json:"envFrom,omitempty"`
-	SkipCreateAdminAccount        *bool                  `json:"skipCreateAdminAccount,omitempty"`
-	PriorityClassName             string                 `json:"priorityClassName,omitempty"`
-	HostNetwork                   *bool                  `json:"hostNetwork,omitempty"`
-	ExtraVolumes                  []v1.Volume            `json:"extraVolumes,omitempty"`
-	ExtraVolumeMounts             []v1.VolumeMount       `json:"extraVolumeMounts,omitempty"`
+	Annotations                   map[string]string          `json:"annotations,omitempty"`
+	Labels                        map[string]string          `json:"labels,omitempty"`
+	Replicas                      int32                      `json:"replicas"`
+	NodeSelector                  map[string]string          `json:"nodeSelector,omitempty"`
+	Tolerations                   []v1.Toleration            `json:"tolerations,omitempty"`
+	Affinity                      *v1.Affinity               `json:"affinity,omitempty"`
+	SecurityContext               *v1.PodSecurityContext     `json:"securityContext,omitempty"`
+	ContainerSecurityContext      *v1.SecurityContext        `json:"containerSecurityContext,omitempty"`
+	TerminationGracePeriodSeconds int64                      `json:"terminationGracePeriodSeconds"`
+	EnvFrom                       []v1.EnvFromSource         `json:"envFrom,omitempty"`
+	SkipCreateAdminAccount        *bool                      `json:"skipCreateAdminAccount,omitempty"`
+	PriorityClassName             string                     `json:"priorityClassName,omitempty"`
+	HostNetwork                   *bool                      `json:"hostNetwork,omitempty"`
+	ExtraVolumes                  []v1.Volume                `json:"extraVolumes,omitempty"`
+	ExtraVolumeMounts             []v1.VolumeMount           `json:"extraVolumeMounts,omitempty"`
+	Strategy                      *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
 }
 
 // GrafanaIngress provides a means to configure the ingress created

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -1623,6 +1624,11 @@ func (in *GrafanaDeployment) DeepCopyInto(out *GrafanaDeployment) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(appsv1.DeploymentStrategy)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -115,6 +115,17 @@ func getReplicas(cr *v1alpha1.Grafana) *int32 {
 	}
 }
 
+func getDeploymentStrategy(cr *v1alpha1.Grafana) v1.DeploymentStrategy {
+	if cr.Spec.Deployment != nil && cr.Spec.Deployment.Strategy != nil {
+		return *cr.Spec.Deployment.Strategy
+	}
+
+	return v1.DeploymentStrategy{
+		Type:          "RollingUpdate",
+		RollingUpdate: getRollingUpdateStrategy(),
+	}
+}
+
 func getRollingUpdateStrategy() *v1.RollingUpdateDeployment {
 	var maxUnaval intstr.IntOrString = intstr.FromString("25%")
 	var maxSurge intstr.IntOrString = intstr.FromString("25%")
@@ -597,10 +608,7 @@ func getDeploymentSpec(cr *v1alpha1.Grafana, annotations map[string]string, conf
 				PriorityClassName:             getPodPriorityClassName(cr),
 			},
 		},
-		Strategy: v1.DeploymentStrategy{
-			Type:          "RollingUpdate",
-			RollingUpdate: getRollingUpdateStrategy(),
-		},
+		Strategy: getDeploymentStrategy(cr),
 	}
 }
 


### PR DESCRIPTION
Backport 558b175a119ac3fc7ab70b94b1ce8598ea52d4d9 to v3 branch.

## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->

Add support to override default deployment strategy

This change adds support to override the default deployment strategy
given to Grafana deployments through the Grafana CRD.
The existing default behaviour remains unchanged, but override can
now be performed by setting Deployment.Strategy on the GrafanaSpec.

This is particularly useful for deployments that use RWO PVC storage
where deployment strategy type 'Recreate' is required.

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
 
#415 #463 #453 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
