### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab
+
+[*.{md,yml,yaml}]
+indent_size = 2
+
+[{Makefile,*.mk}]
+indent_style = tab


### PR DESCRIPTION
In #508, my commits included whitespace errors (text files with no `\n` on the last line).

This adds an `.editorconfig` file to automatically configure text editors to insert that final newline, and to configure indentation.