### PR TITLE
Add known field 'clusterUrl' for Azure data sources

### DIFF
--- a/api/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/api/integreatly/v1alpha1/grafanadatasource_types.go
@@ -143,6 +143,7 @@ type GrafanaDataSourceJsonData struct {
 	AppInsightsAppId             string `json:"appInsightsAppId,omitempty"`
 	AzureLogAnalyticsSameAs      string `json:"azureLogAnalyticsSameAs,omitempty"`
 	ClientId                     string `json:"clientId,omitempty"`
+	ClusterURL                   string `json:"clusterUrl,omitempty"`
 	CloudName                    string `json:"cloudName,omitempty"`
 	LogAnalyticsDefaultWorkspace string `json:"logAnalyticsDefaultWorkspace,omitempty"`
 	LogAnalyticsClientId         string `json:"logAnalyticsClientId,omitempty"`

--- a/config/crd/bases/integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/integreatly.org_grafanadatasources.yaml
@@ -78,6 +78,8 @@ spec:
                           type: string
                         cloudName:
                           type: string
+                        clusterUrl:
+                          type: string
                         connMaxLifetime:
                           type: integer
                         customMetricsNamespaces:

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -562,6 +562,13 @@ The most common json options See https://grafana.com/docs/administration/provisi
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>clusterUrl</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>connMaxLifetime</b></td>
         <td>integer</td>
         <td>


### PR DESCRIPTION
## Description
Add the field 'clusterUrl' for Azure Data Sources (e.g. Azure Data Explorer).

## Relevant issues/tickets
https://github.com/grafana-operator/grafana-operator/issues/523

## Type of change
- [x] New feature (non-breaking change which adds functionality)