### PR TITLE
Use markdownlint-cli instead of github super-linter

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -97,7 +97,7 @@ jobs:
           make test
 
   build:
-    name: github super-linter
+    name: markdownlint-cli
     runs-on: ubuntu-latest
 
     steps:
@@ -105,16 +105,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: super-linter
-        uses: docker://ghcr.io/github/super-linter:slim-v4
-        env:
-          VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # VALIDATE_GITHUB_ACTIONS: true
-          VALIDATE_MARKDOWN: true
-          # VALIDATE_YAML: false
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: npm install -g markdownlint-cli
+      - run: /usr/bin/markdownlint -c .markdown-lint.yml .
 
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -108,8 +108,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
-      - run: npm install -g markdownlint-cli
-      - run: /usr/bin/markdownlint -c .markdown-lint.yml .
+      - run: npm install markdownlint-cli
+      - run: node_modules/.bin/markdownlint -c .markdown-lint.yml -i node_modules .
 
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           node-version: '16'
       - run: npm install markdownlint-cli
-      - run: node_modules/.bin/markdownlint -c .markdown-lint.yml -i node_modules .
+      - run: make markdownlint
 
   build-container:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ operator-sdk-*
 tmp
 manager
 vendor
+
+# nodejs
+node_modules/
+package*

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,16 @@ cluster/prepare/local: cluster/prepare/local/file
 	kubectl apply -f deploy/cluster_roles
 	kubectl apply -f deploy/examples/Grafana.yaml -n ${NAMESPACE}
 
+# markdownlint-cli
+# Assumes that you have npm installed
+.PHONY: markdownlint-install
+markdownlint-install:
+	npm install markdownlint-cli
+
+.PHONY: markdownlint
+markdownlint:
+	node_modules/.bin/markdownlint -c .markdown-lint.yml -i node_modules/ -i grafonnet-lib/ .
+
 # Find or download gen-crd-api-reference-docs
 gen-crd-api-reference-docs:
 ifeq (, $(shell which crdoc))

--- a/documentation/develop.md
+++ b/documentation/develop.md
@@ -36,6 +36,7 @@ We will go through two sections.
 ### Kind load docker-image
 
 This solution assumes that you are using kind in your development environment.
+
 ```shell
 make generate
 make install

--- a/documentation/develop.md
+++ b/documentation/develop.md
@@ -36,7 +36,6 @@ We will go through two sections.
 ### Kind load docker-image
 
 This solution assumes that you are using kind in your development environment.
-
 ```shell
 make generate
 make install


### PR DESCRIPTION
## Description
The github super-linter created issues and I spent way to much time debugging it, so I change over to using markdownlint-cli straight up instead.
People that knows npm will probably think this is a really ugly solution, if so please come with a better one, all i know is that this works :) 

## Relevant issues/tickets
N/A

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
See: https://github.com/NissesSenap/grafana-operator/pull/6

