### PR TITLE
add nullable to non struct pointer fields to support cr migration

### DIFF
--- a/api/integreatly/v1alpha1/grafana_types.go
+++ b/api/integreatly/v1alpha1/grafana_types.go
@@ -62,9 +62,9 @@ type JsonnetConfig struct {
 // Grafana API client settings
 type GrafanaClient struct {
 	// +nullable
-	TimeoutSeconds *int  `json:"timeout,omitempty"`
+	TimeoutSeconds *int `json:"timeout,omitempty"`
 	// +nullable
-	PreferService  *bool `json:"preferService,omitempty"`
+	PreferService *bool `json:"preferService,omitempty"`
 }
 
 // GrafanaService provides a means to configure the service
@@ -95,27 +95,27 @@ type GrafanaServiceAccount struct {
 
 // GrafanaDeployment provides a means to configure the deployment
 type GrafanaDeployment struct {
-	Annotations                   map[string]string          `json:"annotations,omitempty"`
-	Labels                        map[string]string          `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	// +nullable
-	Replicas                      *int32                     `json:"replicas,omitempty"`
-	NodeSelector                  map[string]string          `json:"nodeSelector,omitempty"`
-	Tolerations                   []v1.Toleration            `json:"tolerations,omitempty"`
-	Affinity                      *v1.Affinity               `json:"affinity,omitempty"`
-	SecurityContext               *v1.PodSecurityContext     `json:"securityContext,omitempty"`
-	ContainerSecurityContext      *v1.SecurityContext        `json:"containerSecurityContext,omitempty"`
-	TerminationGracePeriodSeconds *int64                     `json:"terminationGracePeriodSeconds,omitempty"`
-	EnvFrom                       []v1.EnvFromSource         `json:"envFrom,omitempty"`
-	Env                           []v1.EnvVar                `json:"env,omitempty"`
+	Replicas                      *int32                 `json:"replicas,omitempty"`
+	NodeSelector                  map[string]string      `json:"nodeSelector,omitempty"`
+	Tolerations                   []v1.Toleration        `json:"tolerations,omitempty"`
+	Affinity                      *v1.Affinity           `json:"affinity,omitempty"`
+	SecurityContext               *v1.PodSecurityContext `json:"securityContext,omitempty"`
+	ContainerSecurityContext      *v1.SecurityContext    `json:"containerSecurityContext,omitempty"`
+	TerminationGracePeriodSeconds *int64                 `json:"terminationGracePeriodSeconds,omitempty"`
+	EnvFrom                       []v1.EnvFromSource     `json:"envFrom,omitempty"`
+	Env                           []v1.EnvVar            `json:"env,omitempty"`
 	// +nullable
-	SkipCreateAdminAccount        *bool                      `json:"skipCreateAdminAccount,omitempty"`
-	PriorityClassName             string                     `json:"priorityClassName,omitempty"`
+	SkipCreateAdminAccount *bool  `json:"skipCreateAdminAccount,omitempty"`
+	PriorityClassName      string `json:"priorityClassName,omitempty"`
 	// +nullable
-	HostNetwork                   *bool                      `json:"hostNetwork,omitempty"`
-	ExtraVolumes                  []v1.Volume                `json:"extraVolumes,omitempty"`
-	ExtraVolumeMounts             []v1.VolumeMount           `json:"extraVolumeMounts,omitempty"`
-	Strategy                      *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
-	HttpProxy                     *GrafanaHttpProxy          `json:"httpProxy,omitempty"`
+	HostNetwork       *bool                      `json:"hostNetwork,omitempty"`
+	ExtraVolumes      []v1.Volume                `json:"extraVolumes,omitempty"`
+	ExtraVolumeMounts []v1.VolumeMount           `json:"extraVolumeMounts,omitempty"`
+	Strategy          *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
+	HttpProxy         *GrafanaHttpProxy          `json:"httpProxy,omitempty"`
 }
 
 // GrafanaHttpProxy provides a means to configure the Grafana deployment
@@ -188,47 +188,47 @@ type GrafanaConfigPaths struct {
 }
 
 type GrafanaConfigServer struct {
-	HttpAddr         string `json:"http_addr,omitempty" ini:"http_addr,omitempty"`
-	HttpPort         string `json:"http_port,omitempty" ini:"http_port,omitempty"`
-	Protocol         string `json:"protocol,omitempty" ini:"protocol,omitempty"`
-	Socket           string `json:"socket,omitempty" ini:"socket,omitempty"`
-	Domain           string `json:"domain,omitempty" ini:"domain,omitempty"`
+	HttpAddr string `json:"http_addr,omitempty" ini:"http_addr,omitempty"`
+	HttpPort string `json:"http_port,omitempty" ini:"http_port,omitempty"`
+	Protocol string `json:"protocol,omitempty" ini:"protocol,omitempty"`
+	Socket   string `json:"socket,omitempty" ini:"socket,omitempty"`
+	Domain   string `json:"domain,omitempty" ini:"domain,omitempty"`
 	// +nullable
-	EnforceDomain    *bool  `json:"enforce_domain,omitempty" ini:"enforce_domain"`
-	RootUrl          string `json:"root_url,omitempty" ini:"root_url,omitempty"`
+	EnforceDomain *bool  `json:"enforce_domain,omitempty" ini:"enforce_domain"`
+	RootUrl       string `json:"root_url,omitempty" ini:"root_url,omitempty"`
 	// +nullable
 	ServeFromSubPath *bool  `json:"serve_from_sub_path,omitempty" ini:"serve_from_sub_path"`
 	StaticRootPath   string `json:"static_root_path,omitempty" ini:"static_root_path,omitempty"`
 	// +nullable
-	EnableGzip       *bool  `json:"enable_gzip,omitempty" ini:"enable_gzip"`
-	CertFile         string `json:"cert_file,omitempty" ini:"cert_file,omitempty"`
-	CertKey          string `json:"cert_key,omitempty" ini:"cert_key,omitempty"`
+	EnableGzip *bool  `json:"enable_gzip,omitempty" ini:"enable_gzip"`
+	CertFile   string `json:"cert_file,omitempty" ini:"cert_file,omitempty"`
+	CertKey    string `json:"cert_key,omitempty" ini:"cert_key,omitempty"`
 	// +nullable
-	RouterLogging    *bool  `json:"router_logging,omitempty" ini:"router_logging"`
+	RouterLogging *bool `json:"router_logging,omitempty" ini:"router_logging"`
 }
 
 type GrafanaConfigDatabase struct {
-	Url             string `json:"url,omitempty" ini:"url,omitempty"`
-	Type            string `json:"type,omitempty" ini:"type,omitempty"`
-	Path            string `json:"path,omitempty" ini:"path,omitempty"`
-	Host            string `json:"host,omitempty" ini:"host,omitempty"`
-	Name            string `json:"name,omitempty" ini:"name,omitempty"`
-	User            string `json:"user,omitempty" ini:"user,omitempty"`
-	Password        string `json:"password,omitempty" ini:"password,omitempty"`
-	SslMode         string `json:"ssl_mode,omitempty" ini:"ssl_mode,omitempty"`
-	CaCertPath      string `json:"ca_cert_path,omitempty" ini:"ca_cert_path,omitempty"`
-	ClientKeyPath   string `json:"client_key_path,omitempty" ini:"client_key_path,omitempty"`
-	ClientCertPath  string `json:"client_cert_path,omitempty" ini:"client_cert_path,omitempty"`
-	ServerCertName  string `json:"server_cert_name,omitempty" ini:"server_cert_name,omitempty"`
+	Url            string `json:"url,omitempty" ini:"url,omitempty"`
+	Type           string `json:"type,omitempty" ini:"type,omitempty"`
+	Path           string `json:"path,omitempty" ini:"path,omitempty"`
+	Host           string `json:"host,omitempty" ini:"host,omitempty"`
+	Name           string `json:"name,omitempty" ini:"name,omitempty"`
+	User           string `json:"user,omitempty" ini:"user,omitempty"`
+	Password       string `json:"password,omitempty" ini:"password,omitempty"`
+	SslMode        string `json:"ssl_mode,omitempty" ini:"ssl_mode,omitempty"`
+	CaCertPath     string `json:"ca_cert_path,omitempty" ini:"ca_cert_path,omitempty"`
+	ClientKeyPath  string `json:"client_key_path,omitempty" ini:"client_key_path,omitempty"`
+	ClientCertPath string `json:"client_cert_path,omitempty" ini:"client_cert_path,omitempty"`
+	ServerCertName string `json:"server_cert_name,omitempty" ini:"server_cert_name,omitempty"`
 	// +nullable
-	MaxIdleConn     *int   `json:"max_idle_conn,omitempty" ini:"max_idle_conn,omitempty"`
+	MaxIdleConn *int `json:"max_idle_conn,omitempty" ini:"max_idle_conn,omitempty"`
 	// +nullable
-	MaxOpenConn     *int   `json:"max_open_conn,omitempty" ini:"max_open_conn,omitempty"`
+	MaxOpenConn *int `json:"max_open_conn,omitempty" ini:"max_open_conn,omitempty"`
 	// +nullable
-	ConnMaxLifetime *int   `json:"conn_max_lifetime,omitempty" ini:"conn_max_lifetime,omitempty"`
+	ConnMaxLifetime *int `json:"conn_max_lifetime,omitempty" ini:"conn_max_lifetime,omitempty"`
 	// +nullable
-	LogQueries      *bool  `json:"log_queries,omitempty" ini:"log_queries"`
-	CacheMode       string `json:"cache_mode,omitempty" ini:"cache_mode,omitempty"`
+	LogQueries *bool  `json:"log_queries,omitempty" ini:"log_queries"`
+	CacheMode  string `json:"cache_mode,omitempty" ini:"cache_mode,omitempty"`
 }
 
 type GrafanaConfigRemoteCache struct {
@@ -237,70 +237,70 @@ type GrafanaConfigRemoteCache struct {
 }
 
 type GrafanaConfigSecurity struct {
-	AdminUser                            string `json:"admin_user,omitempty" ini:"admin_user,omitempty"`
-	AdminPassword                        string `json:"admin_password,omitempty" ini:"admin_password,omitempty"`
+	AdminUser     string `json:"admin_user,omitempty" ini:"admin_user,omitempty"`
+	AdminPassword string `json:"admin_password,omitempty" ini:"admin_password,omitempty"`
 	// +nullable
-	LoginRememberDays                    *int   `json:"login_remember_days,omitempty" ini:"login_remember_days,omitempty"`
-	SecretKey                            string `json:"secret_key,omitempty" ini:"secret_key,omitempty"`
+	LoginRememberDays *int   `json:"login_remember_days,omitempty" ini:"login_remember_days,omitempty"`
+	SecretKey         string `json:"secret_key,omitempty" ini:"secret_key,omitempty"`
 	// +nullable
-	DisableGravatar                      *bool  `json:"disable_gravatar,omitempty" ini:"disable_gravatar"`
-	DataSourceProxyWhitelist             string `json:"data_source_proxy_whitelist,omitempty" ini:"data_source_proxy_whitelist,omitempty"`
+	DisableGravatar          *bool  `json:"disable_gravatar,omitempty" ini:"disable_gravatar"`
+	DataSourceProxyWhitelist string `json:"data_source_proxy_whitelist,omitempty" ini:"data_source_proxy_whitelist,omitempty"`
 	// +nullable
-	CookieSecure                         *bool  `json:"cookie_secure,omitempty" ini:"cookie_secure"`
-	CookieSamesite                       string `json:"cookie_samesite,omitempty" ini:"cookie_samesite,omitempty"`
+	CookieSecure   *bool  `json:"cookie_secure,omitempty" ini:"cookie_secure"`
+	CookieSamesite string `json:"cookie_samesite,omitempty" ini:"cookie_samesite,omitempty"`
 	// +nullable
-	AllowEmbedding                       *bool  `json:"allow_embedding,omitempty" ini:"allow_embedding"`
+	AllowEmbedding *bool `json:"allow_embedding,omitempty" ini:"allow_embedding"`
 	// +nullable
-	StrictTransportSecurity              *bool  `json:"strict_transport_security,omitempty" ini:"strict_transport_security"`
+	StrictTransportSecurity *bool `json:"strict_transport_security,omitempty" ini:"strict_transport_security"`
 	// +nullable
-	StrictTransportSecurityMaxAgeSeconds *int   `json:"strict_transport_security_max_age_seconds,omitempty" ini:"strict_transport_security_max_age_seconds,omitempty"`
+	StrictTransportSecurityMaxAgeSeconds *int `json:"strict_transport_security_max_age_seconds,omitempty" ini:"strict_transport_security_max_age_seconds,omitempty"`
 	// +nullable
-	StrictTransportSecurityPreload       *bool  `json:"strict_transport_security_preload,omitempty" ini:"strict_transport_security_preload"`
+	StrictTransportSecurityPreload *bool `json:"strict_transport_security_preload,omitempty" ini:"strict_transport_security_preload"`
 	// +nullable
-	StrictTransportSecuritySubdomains    *bool  `json:"strict_transport_security_subdomains,omitempty" ini:"strict_transport_security_subdomains"`
+	StrictTransportSecuritySubdomains *bool `json:"strict_transport_security_subdomains,omitempty" ini:"strict_transport_security_subdomains"`
 	// +nullable
-	XContentTypeOptions                  *bool  `json:"x_content_type_options,omitempty" ini:"x_content_type_options"`
+	XContentTypeOptions *bool `json:"x_content_type_options,omitempty" ini:"x_content_type_options"`
 	// +nullable
-	XXssProtection                       *bool  `json:"x_xss_protection,omitempty" ini:"x_xss_protection"`
+	XXssProtection *bool `json:"x_xss_protection,omitempty" ini:"x_xss_protection"`
 }
 
 type GrafanaConfigUsers struct {
 	// +nullable
-	AllowSignUp       *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
+	AllowSignUp *bool `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	// +nullable
-	AllowOrgCreate    *bool  `json:"allow_org_create,omitempty" ini:"allow_org_create"`
+	AllowOrgCreate *bool `json:"allow_org_create,omitempty" ini:"allow_org_create"`
 	// +nullable
 	AutoAssignOrg     *bool  `json:"auto_assign_org,omitempty" ini:"auto_assign_org"`
 	AutoAssignOrgId   string `json:"auto_assign_org_id,omitempty" ini:"auto_assign_org_id,omitempty"`
 	AutoAssignOrgRole string `json:"auto_assign_org_role,omitempty" ini:"auto_assign_org_role,omitempty"`
 	// +nullable
-	ViewersCanEdit    *bool  `json:"viewers_can_edit,omitempty" ini:"viewers_can_edit"`
+	ViewersCanEdit *bool `json:"viewers_can_edit,omitempty" ini:"viewers_can_edit"`
 	// +nullable
-	EditorsCanAdmin   *bool  `json:"editors_can_admin,omitempty" ini:"editors_can_admin"`
-	LoginHint         string `json:"login_hint,omitempty" ini:"login_hint,omitempty"`
-	PasswordHint      string `json:"password_hint,omitempty" ini:"password_hint,omitempty"`
-	DefaultTheme      string `json:"default_theme,omitempty" ini:"default_theme,omitempty"`
+	EditorsCanAdmin *bool  `json:"editors_can_admin,omitempty" ini:"editors_can_admin"`
+	LoginHint       string `json:"login_hint,omitempty" ini:"login_hint,omitempty"`
+	PasswordHint    string `json:"password_hint,omitempty" ini:"password_hint,omitempty"`
+	DefaultTheme    string `json:"default_theme,omitempty" ini:"default_theme,omitempty"`
 }
 
 type GrafanaConfigAuth struct {
-	LoginCookieName                      string `json:"login_cookie_name,omitempty" ini:"login_cookie_name,omitempty"`
+	LoginCookieName string `json:"login_cookie_name,omitempty" ini:"login_cookie_name,omitempty"`
 	// +nullable
 	LoginMaximumInactiveLifetimeDays     *int   `json:"login_maximum_inactive_lifetime_days,omitempty" ini:"login_maximum_inactive_lifetime_days,omitempty"`
 	LoginMaximumInactiveLifetimeDuration string `json:"login_maximum_inactive_lifetime_duration,omitempty" ini:"login_maximum_inactive_lifetime_duration,omitempty"`
 	// +nullable
-	LoginMaximumLifetimeDays             *int   `json:"login_maximum_lifetime_days,omitempty" ini:"login_maximum_lifetime_days,omitempty"`
-	LoginMaximumLifetimeDuration         string `json:"login_maximum_lifetime_duration,omitempty" ini:"login_maximum_lifetime_duration,omitempty"`
+	LoginMaximumLifetimeDays     *int   `json:"login_maximum_lifetime_days,omitempty" ini:"login_maximum_lifetime_days,omitempty"`
+	LoginMaximumLifetimeDuration string `json:"login_maximum_lifetime_duration,omitempty" ini:"login_maximum_lifetime_duration,omitempty"`
 	// +nullable
-	TokenRotationIntervalMinutes         *int   `json:"token_rotation_interval_minutes,omitempty" ini:"token_rotation_interval_minutes,omitempty"`
+	TokenRotationIntervalMinutes *int `json:"token_rotation_interval_minutes,omitempty" ini:"token_rotation_interval_minutes,omitempty"`
 	// +nullable
-	DisableLoginForm                     *bool  `json:"disable_login_form,omitempty" ini:"disable_login_form"`
+	DisableLoginForm *bool `json:"disable_login_form,omitempty" ini:"disable_login_form"`
 	// +nullable
-	DisableSignoutMenu                   *bool  `json:"disable_signout_menu,omitempty" ini:"disable_signout_menu"`
+	DisableSignoutMenu *bool `json:"disable_signout_menu,omitempty" ini:"disable_signout_menu"`
 	// +nullable
-	SigV4AuthEnabled                     *bool  `json:"sigv4_auth_enabled,omitempty" ini:"sigv4_auth_enabled"`
-	SignoutRedirectUrl                   string `json:"signout_redirect_url,omitempty" ini:"signout_redirect_url,omitempty"`
+	SigV4AuthEnabled   *bool  `json:"sigv4_auth_enabled,omitempty" ini:"sigv4_auth_enabled"`
+	SignoutRedirectUrl string `json:"signout_redirect_url,omitempty" ini:"signout_redirect_url,omitempty"`
 	// +nullable
-	OauthAutoLogin                       *bool  `json:"oauth_auto_login,omitempty" ini:"oauth_auto_login"`
+	OauthAutoLogin *bool `json:"oauth_auto_login,omitempty" ini:"oauth_auto_login"`
 }
 
 type GrafanaConfigAuthBasic struct {
@@ -317,9 +317,9 @@ type GrafanaConfigAuthAnonymous struct {
 
 type GrafanaConfigAuthSaml struct {
 	// +nullable
-	Enabled                  *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 	// +nullable
-	SingleLogout             *bool  `json:"single_logout,omitempty" ini:"single_logout,omitempty"`
+	SingleLogout *bool `json:"single_logout,omitempty" ini:"single_logout,omitempty"`
 	// +nullable
 	AllowIdpInitiated        *bool  `json:"allow_idp_initiated,omitempty" ini:"allow_idp_initiated,omitempty"`
 	CertificatePath          string `json:"certificate_path,omitempty" ini:"certificate_path"`
@@ -344,7 +344,7 @@ type GrafanaConfigAuthSaml struct {
 
 type GrafanaConfigAuthAzureAD struct {
 	// +nullable
-	Enabled        *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 	// +nullable
 	AllowSignUp    *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId       string `json:"client_id,omitempty" ini:"client_id,omitempty"`
@@ -370,7 +370,7 @@ type GrafanaConfigAuthGoogle struct {
 
 type GrafanaConfigAuthGithub struct {
 	// +nullable
-	Enabled              *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 	// +nullable
 	AllowSignUp          *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId             string `json:"client_id,omitempty" ini:"client_id,omitempty"`
@@ -385,7 +385,7 @@ type GrafanaConfigAuthGithub struct {
 
 type GrafanaConfigAuthGitlab struct {
 	// +nullable
-	Enabled       *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 	// +nullable
 	AllowSignUp   *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId      string `json:"client_id,omitempty" ini:"client_id,omitempty"`
@@ -399,20 +399,20 @@ type GrafanaConfigAuthGitlab struct {
 
 type GrafanaConfigAuthGenericOauth struct {
 	// +nullable
-	Enabled               *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 	// +nullable
-	AllowSignUp           *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
-	ClientId              string `json:"client_id,omitempty" ini:"client_id,omitempty"`
-	ClientSecret          string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
-	Scopes                string `json:"scopes,omitempty" ini:"scopes,omitempty"`
-	AuthUrl               string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
-	TokenUrl              string `json:"token_url,omitempty" ini:"token_url,omitempty"`
-	ApiUrl                string `json:"api_url,omitempty" ini:"api_url,omitempty"`
-	AllowedDomains        string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
-	RoleAttributePath     string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	AllowSignUp       *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
+	ClientId          string `json:"client_id,omitempty" ini:"client_id,omitempty"`
+	ClientSecret      string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
+	Scopes            string `json:"scopes,omitempty" ini:"scopes,omitempty"`
+	AuthUrl           string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
+	TokenUrl          string `json:"token_url,omitempty" ini:"token_url,omitempty"`
+	ApiUrl            string `json:"api_url,omitempty" ini:"api_url,omitempty"`
+	AllowedDomains    string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
+	RoleAttributePath string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
 	// +nullable
-	RoleAttributeStrict   *bool  `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
-	EmailAttributePath    string `json:"email_attribute_path,omitempty" ini:"email_attribute_path,omitempty"`
+	RoleAttributeStrict *bool  `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
+	EmailAttributePath  string `json:"email_attribute_path,omitempty" ini:"email_attribute_path,omitempty"`
 	// +nullable
 	TLSSkipVerifyInsecure *bool  `json:"tls_skip_verify_insecure,omitempty" ini:"tls_skip_verify_insecure,omitempty"`
 	TLSClientCert         string `json:"tls_client_cert,omitempty" ini:"tls_client_cert,omitempty"`
@@ -422,26 +422,26 @@ type GrafanaConfigAuthGenericOauth struct {
 
 type GrafanaConfigAuthOkta struct {
 	// +nullable
-	Enabled             *bool  `json:"enabled,omitempty" ini:"enabled"`
-	Name                string `json:"name,omitempty" ini:"name,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Name    string `json:"name,omitempty" ini:"name,omitempty"`
 	// +nullable
-	AllowSignUp         *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
-	ClientId            string `json:"client_id,omitempty" ini:"client_id,omitempty"`
-	ClientSecret        string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
-	Scopes              string `json:"scopes,omitempty" ini:"scopes,omitempty"`
-	AuthUrl             string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
-	TokenUrl            string `json:"token_url,omitempty" ini:"token_url,omitempty"`
-	ApiUrl              string `json:"api_url,omitempty" ini:"api_url,omitempty"`
-	AllowedDomains      string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
-	AllowedGroups       string `json:"allowed_groups,omitempty" ini:"allowed_groups,omitempty"`
-	RoleAttributePath   string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	AllowSignUp       *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
+	ClientId          string `json:"client_id,omitempty" ini:"client_id,omitempty"`
+	ClientSecret      string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
+	Scopes            string `json:"scopes,omitempty" ini:"scopes,omitempty"`
+	AuthUrl           string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
+	TokenUrl          string `json:"token_url,omitempty" ini:"token_url,omitempty"`
+	ApiUrl            string `json:"api_url,omitempty" ini:"api_url,omitempty"`
+	AllowedDomains    string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
+	AllowedGroups     string `json:"allowed_groups,omitempty" ini:"allowed_groups,omitempty"`
+	RoleAttributePath string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
 	// +nullable
-	RoleAttributeStrict *bool  `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
+	RoleAttributeStrict *bool `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
 }
 
 type GrafanaConfigAuthLdap struct {
 	// +nullable
-	Enabled     *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 	// +nullable
 	AllowSignUp *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ConfigFile  string `json:"config_file,omitempty" ini:"config_file,omitempty"`
@@ -449,23 +449,23 @@ type GrafanaConfigAuthLdap struct {
 
 type GrafanaConfigAuthProxy struct {
 	// +nullable
-	Enabled          *bool  `json:"enabled,omitempty" ini:"enabled"`
-	HeaderName       string `json:"header_name,omitempty" ini:"header_name,omitempty"`
-	HeaderProperty   string `json:"header_property,omitempty" ini:"header_property,omitempty"`
+	Enabled        *bool  `json:"enabled,omitempty" ini:"enabled"`
+	HeaderName     string `json:"header_name,omitempty" ini:"header_name,omitempty"`
+	HeaderProperty string `json:"header_property,omitempty" ini:"header_property,omitempty"`
 	// +nullable
-	AutoSignUp       *bool  `json:"auto_sign_up,omitempty" ini:"auto_sign_up"`
-	LdapSyncTtl      string `json:"ldap_sync_ttl,omitempty" ini:"ldap_sync_ttl,omitempty"`
-	Whitelist        string `json:"whitelist,omitempty" ini:"whitelist,omitempty"`
-	Headers          string `json:"headers,omitempty" ini:"headers,omitempty"`
+	AutoSignUp  *bool  `json:"auto_sign_up,omitempty" ini:"auto_sign_up"`
+	LdapSyncTtl string `json:"ldap_sync_ttl,omitempty" ini:"ldap_sync_ttl,omitempty"`
+	Whitelist   string `json:"whitelist,omitempty" ini:"whitelist,omitempty"`
+	Headers     string `json:"headers,omitempty" ini:"headers,omitempty"`
 	// +nullable
-	EnableLoginToken *bool  `json:"enable_login_token,omitempty" ini:"enable_login_token"`
+	EnableLoginToken *bool `json:"enable_login_token,omitempty" ini:"enable_login_token"`
 }
 
 type GrafanaConfigDataProxy struct {
 	// +nullable
-	Logging        *bool `json:"logging,omitempty" ini:"logging"`
+	Logging *bool `json:"logging,omitempty" ini:"logging"`
 	// +nullable
-	Timeout        *int  `json:"timeout,omitempty" ini:"timeout,omitempty"`
+	Timeout *int `json:"timeout,omitempty" ini:"timeout,omitempty"`
 	// +nullable
 	SendUserHeader *bool `json:"send_user_header,omitempty" ini:"send_user_header,omitempty"`
 }
@@ -475,7 +475,7 @@ type GrafanaConfigAnalytics struct {
 	ReportingEnabled    *bool  `json:"reporting_enabled,omitempty" ini:"reporting_enabled"`
 	GoogleAnalyticsUaId string `json:"google_analytics_ua_id,omitempty" ini:"google_analytics_ua_id,omitempty"`
 	// +nullable
-	CheckForUpdates     *bool  `json:"check_for_updates,omitempty" ini:"check_for_updates"`
+	CheckForUpdates *bool `json:"check_for_updates,omitempty" ini:"check_for_updates"`
 }
 
 type GrafanaConfigDashboards struct {
@@ -485,12 +485,12 @@ type GrafanaConfigDashboards struct {
 
 type GrafanaConfigSmtp struct {
 	// +nullable
-	Enabled      *bool  `json:"enabled,omitempty" ini:"enabled"`
-	Host         string `json:"host,omitempty" ini:"host,omitempty"`
-	User         string `json:"user,omitempty" ini:"user,omitempty"`
-	Password     string `json:"password,omitempty" ini:"password,omitempty"`
-	CertFile     string `json:"cert_file,omitempty" ini:"cert_file,omitempty"`
-	KeyFile      string `json:"key_file,omitempty" ini:"key_file,omitempty"`
+	Enabled  *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Host     string `json:"host,omitempty" ini:"host,omitempty"`
+	User     string `json:"user,omitempty" ini:"user,omitempty"`
+	Password string `json:"password,omitempty" ini:"password,omitempty"`
+	CertFile string `json:"cert_file,omitempty" ini:"cert_file,omitempty"`
+	KeyFile  string `json:"key_file,omitempty" ini:"key_file,omitempty"`
 	// +nullable
 	SkipVerify   *bool  `json:"skip_verify,omitempty" ini:"skip_verify"`
 	FromAddress  string `json:"from_address,omitempty" ini:"from_address,omitempty"`
@@ -512,14 +512,14 @@ type GrafanaConfigLog struct {
 
 type GrafanaConfigLogFrontend struct {
 	// +nullable
-	Enabled                           *bool  `json:"enabled,omitempty" ini:"enabled,omitempty"`
-	SentryDsn                         string `json:"sentry_dsn,omitempty" ini:"sentry_dsn,omitempty"`
-	CustomEndpoint                    string `json:"custom_endpoint,omitempty" ini:"custom_endpoint,omitempty"`
-	SampleRate                        string `json:"sample_rate,omitempty" ini:"sample_rate,omitempty"`
+	Enabled        *bool  `json:"enabled,omitempty" ini:"enabled,omitempty"`
+	SentryDsn      string `json:"sentry_dsn,omitempty" ini:"sentry_dsn,omitempty"`
+	CustomEndpoint string `json:"custom_endpoint,omitempty" ini:"custom_endpoint,omitempty"`
+	SampleRate     string `json:"sample_rate,omitempty" ini:"sample_rate,omitempty"`
 	// +nullable
-	LogEndpointRequestsPerSecondLimit *int   `json:"log_endpoint_requests_per_second_limit,omitempty" ini:"log_endpoint_requests_per_second_limit,omitempty"`
+	LogEndpointRequestsPerSecondLimit *int `json:"log_endpoint_requests_per_second_limit,omitempty" ini:"log_endpoint_requests_per_second_limit,omitempty"`
 	// +nullable
-	LogEndpointBurstLimit             *int   `json:"log_endpoint_burst_limit,omitempty" ini:"log_endpoint_burst_limit,omitempty"`
+	LogEndpointBurstLimit *int `json:"log_endpoint_burst_limit,omitempty" ini:"log_endpoint_burst_limit,omitempty"`
 }
 
 type GrafanaConfigLogConsole struct {
@@ -533,7 +533,7 @@ type GrafanaConfigMetrics struct {
 	BasicAuthUsername string `json:"basic_auth_username,omitempty" ini:"basic_auth_username,omitempty"`
 	BasicAuthPassword string `json:"basic_auth_password,omitempty" ini:"basic_auth_password,omitempty"`
 	// +nullable
-	IntervalSeconds   *int   `json:"interval_seconds,omitempty" ini:"interval_seconds,omitempty"`
+	IntervalSeconds *int `json:"interval_seconds,omitempty" ini:"interval_seconds,omitempty"`
 }
 
 type GrafanaConfigMetricsGraphite struct {
@@ -543,11 +543,11 @@ type GrafanaConfigMetricsGraphite struct {
 
 type GrafanaConfigSnapshots struct {
 	// +nullable
-	ExternalEnabled       *bool  `json:"external_enabled,omitempty" ini:"external_enabled"`
-	ExternalSnapshotUrl   string `json:"external_snapshot_url,omitempty" ini:"external_snapshot_url,omitempty"`
-	ExternalSnapshotName  string `json:"external_snapshot_name,omitempty" ini:"external_snapshot_name,omitempty"`
+	ExternalEnabled      *bool  `json:"external_enabled,omitempty" ini:"external_enabled"`
+	ExternalSnapshotUrl  string `json:"external_snapshot_url,omitempty" ini:"external_snapshot_url,omitempty"`
+	ExternalSnapshotName string `json:"external_snapshot_name,omitempty" ini:"external_snapshot_name,omitempty"`
 	// +nullable
-	SnapshotRemoveExpired *bool  `json:"snapshot_remove_expired,omitempty" ini:"snapshot_remove_expired"`
+	SnapshotRemoveExpired *bool `json:"snapshot_remove_expired,omitempty" ini:"snapshot_remove_expired"`
 }
 
 type GrafanaConfigExternalImageStorage struct {
@@ -584,19 +584,19 @@ type GrafanaConfigExternalImageStorageAzureBlob struct {
 
 type GrafanaConfigAlerting struct {
 	// +nullable
-	Enabled                    *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 	// +nullable
-	ExecuteAlerts              *bool  `json:"execute_alerts,omitempty" ini:"execute_alerts"`
-	ErrorOrTimeout             string `json:"error_or_timeout,omitempty" ini:"error_or_timeout,omitempty"`
-	NodataOrNullvalues         string `json:"nodata_or_nullvalues,omitempty" ini:"nodata_or_nullvalues,omitempty"`
+	ExecuteAlerts      *bool  `json:"execute_alerts,omitempty" ini:"execute_alerts"`
+	ErrorOrTimeout     string `json:"error_or_timeout,omitempty" ini:"error_or_timeout,omitempty"`
+	NodataOrNullvalues string `json:"nodata_or_nullvalues,omitempty" ini:"nodata_or_nullvalues,omitempty"`
 	// +nullable
-	ConcurrentRenderLimit      *int   `json:"concurrent_render_limit,omitempty" ini:"concurrent_render_limit,omitempty"`
+	ConcurrentRenderLimit *int `json:"concurrent_render_limit,omitempty" ini:"concurrent_render_limit,omitempty"`
 	// +nullable
-	EvaluationTimeoutSeconds   *int   `json:"evaluation_timeout_seconds,omitempty" ini:"evaluation_timeout_seconds,omitempty"`
+	EvaluationTimeoutSeconds *int `json:"evaluation_timeout_seconds,omitempty" ini:"evaluation_timeout_seconds,omitempty"`
 	// +nullable
-	NotificationTimeoutSeconds *int   `json:"notification_timeout_seconds,omitempty" ini:"notification_timeout_seconds,omitempty"`
+	NotificationTimeoutSeconds *int `json:"notification_timeout_seconds,omitempty" ini:"notification_timeout_seconds,omitempty"`
 	// +nullable
-	MaxAttempts                *int   `json:"max_attempts,omitempty" ini:"max_attempts,omitempty"`
+	MaxAttempts *int `json:"max_attempts,omitempty" ini:"max_attempts,omitempty"`
 }
 
 type GrafanaConfigPanels struct {
@@ -610,10 +610,10 @@ type GrafanaConfigPlugins struct {
 }
 
 type GrafanaConfigRendering struct {
-	ServerURL                    string `json:"server_url,omitempty" ini:"server_url"`
-	CallbackURL                  string `json:"callback_url,omitempty" ini:"callback_url"`
+	ServerURL   string `json:"server_url,omitempty" ini:"server_url"`
+	CallbackURL string `json:"callback_url,omitempty" ini:"callback_url"`
 	// +nullable
-	ConcurrentRenderRequestLimit *int   `json:"concurrent_render_request_limit,omitempty" ini:"concurrent_render_request_limit,omitempty"`
+	ConcurrentRenderRequestLimit *int `json:"concurrent_render_request_limit,omitempty" ini:"concurrent_render_request_limit,omitempty"`
 }
 
 type GrafanaConfigFeatureToggles struct {
@@ -622,15 +622,15 @@ type GrafanaConfigFeatureToggles struct {
 
 // GrafanaStatus defines the observed state of Grafana
 type GrafanaStatus struct {
-	Phase               StatusPhase            `json:"phase,omitempty"`
-	PreviousServiceName string                 `json:"previousServiceName,omitempty"`
-	Message             string                 `json:"message,omitempty"`
+	Phase               StatusPhase `json:"phase,omitempty"`
+	PreviousServiceName string      `json:"previousServiceName,omitempty"`
+	Message             string      `json:"message,omitempty"`
 	// +nullable
 	InstalledDashboards []*GrafanaDashboardRef `json:"dashboards,omitempty"`
 	// +nullable
-	InstalledPlugins    PluginList             `json:"installedPlugins,omitempty"`
+	InstalledPlugins PluginList `json:"installedPlugins,omitempty"`
 	// +nullable
-	FailedPlugins       PluginList             `json:"failedPlugins,omitempty"`
+	FailedPlugins PluginList `json:"failedPlugins,omitempty"`
 }
 
 // GrafanaPlugin contains information about a single plugin

--- a/api/integreatly/v1alpha1/grafana_types.go
+++ b/api/integreatly/v1alpha1/grafana_types.go
@@ -61,7 +61,9 @@ type JsonnetConfig struct {
 
 // Grafana API client settings
 type GrafanaClient struct {
+	// +nullable
 	TimeoutSeconds *int  `json:"timeout,omitempty"`
+	// +nullable
 	PreferService  *bool `json:"preferService,omitempty"`
 }
 
@@ -95,6 +97,7 @@ type GrafanaServiceAccount struct {
 type GrafanaDeployment struct {
 	Annotations                   map[string]string          `json:"annotations,omitempty"`
 	Labels                        map[string]string          `json:"labels,omitempty"`
+	// +nullable
 	Replicas                      *int32                     `json:"replicas,omitempty"`
 	NodeSelector                  map[string]string          `json:"nodeSelector,omitempty"`
 	Tolerations                   []v1.Toleration            `json:"tolerations,omitempty"`
@@ -104,8 +107,10 @@ type GrafanaDeployment struct {
 	TerminationGracePeriodSeconds *int64                     `json:"terminationGracePeriodSeconds,omitempty"`
 	EnvFrom                       []v1.EnvFromSource         `json:"envFrom,omitempty"`
 	Env                           []v1.EnvVar                `json:"env,omitempty"`
+	// +nullable
 	SkipCreateAdminAccount        *bool                      `json:"skipCreateAdminAccount,omitempty"`
 	PriorityClassName             string                     `json:"priorityClassName,omitempty"`
+	// +nullable
 	HostNetwork                   *bool                      `json:"hostNetwork,omitempty"`
 	ExtraVolumes                  []v1.Volume                `json:"extraVolumes,omitempty"`
 	ExtraVolumeMounts             []v1.VolumeMount           `json:"extraVolumeMounts,omitempty"`
@@ -188,13 +193,17 @@ type GrafanaConfigServer struct {
 	Protocol         string `json:"protocol,omitempty" ini:"protocol,omitempty"`
 	Socket           string `json:"socket,omitempty" ini:"socket,omitempty"`
 	Domain           string `json:"domain,omitempty" ini:"domain,omitempty"`
+	// +nullable
 	EnforceDomain    *bool  `json:"enforce_domain,omitempty" ini:"enforce_domain"`
 	RootUrl          string `json:"root_url,omitempty" ini:"root_url,omitempty"`
+	// +nullable
 	ServeFromSubPath *bool  `json:"serve_from_sub_path,omitempty" ini:"serve_from_sub_path"`
 	StaticRootPath   string `json:"static_root_path,omitempty" ini:"static_root_path,omitempty"`
+	// +nullable
 	EnableGzip       *bool  `json:"enable_gzip,omitempty" ini:"enable_gzip"`
 	CertFile         string `json:"cert_file,omitempty" ini:"cert_file,omitempty"`
 	CertKey          string `json:"cert_key,omitempty" ini:"cert_key,omitempty"`
+	// +nullable
 	RouterLogging    *bool  `json:"router_logging,omitempty" ini:"router_logging"`
 }
 
@@ -211,9 +220,13 @@ type GrafanaConfigDatabase struct {
 	ClientKeyPath   string `json:"client_key_path,omitempty" ini:"client_key_path,omitempty"`
 	ClientCertPath  string `json:"client_cert_path,omitempty" ini:"client_cert_path,omitempty"`
 	ServerCertName  string `json:"server_cert_name,omitempty" ini:"server_cert_name,omitempty"`
+	// +nullable
 	MaxIdleConn     *int   `json:"max_idle_conn,omitempty" ini:"max_idle_conn,omitempty"`
+	// +nullable
 	MaxOpenConn     *int   `json:"max_open_conn,omitempty" ini:"max_open_conn,omitempty"`
+	// +nullable
 	ConnMaxLifetime *int   `json:"conn_max_lifetime,omitempty" ini:"conn_max_lifetime,omitempty"`
+	// +nullable
 	LogQueries      *bool  `json:"log_queries,omitempty" ini:"log_queries"`
 	CacheMode       string `json:"cache_mode,omitempty" ini:"cache_mode,omitempty"`
 }
@@ -226,28 +239,43 @@ type GrafanaConfigRemoteCache struct {
 type GrafanaConfigSecurity struct {
 	AdminUser                            string `json:"admin_user,omitempty" ini:"admin_user,omitempty"`
 	AdminPassword                        string `json:"admin_password,omitempty" ini:"admin_password,omitempty"`
+	// +nullable
 	LoginRememberDays                    *int   `json:"login_remember_days,omitempty" ini:"login_remember_days,omitempty"`
 	SecretKey                            string `json:"secret_key,omitempty" ini:"secret_key,omitempty"`
+	// +nullable
 	DisableGravatar                      *bool  `json:"disable_gravatar,omitempty" ini:"disable_gravatar"`
 	DataSourceProxyWhitelist             string `json:"data_source_proxy_whitelist,omitempty" ini:"data_source_proxy_whitelist,omitempty"`
+	// +nullable
 	CookieSecure                         *bool  `json:"cookie_secure,omitempty" ini:"cookie_secure"`
 	CookieSamesite                       string `json:"cookie_samesite,omitempty" ini:"cookie_samesite,omitempty"`
+	// +nullable
 	AllowEmbedding                       *bool  `json:"allow_embedding,omitempty" ini:"allow_embedding"`
+	// +nullable
 	StrictTransportSecurity              *bool  `json:"strict_transport_security,omitempty" ini:"strict_transport_security"`
+	// +nullable
 	StrictTransportSecurityMaxAgeSeconds *int   `json:"strict_transport_security_max_age_seconds,omitempty" ini:"strict_transport_security_max_age_seconds,omitempty"`
+	// +nullable
 	StrictTransportSecurityPreload       *bool  `json:"strict_transport_security_preload,omitempty" ini:"strict_transport_security_preload"`
+	// +nullable
 	StrictTransportSecuritySubdomains    *bool  `json:"strict_transport_security_subdomains,omitempty" ini:"strict_transport_security_subdomains"`
+	// +nullable
 	XContentTypeOptions                  *bool  `json:"x_content_type_options,omitempty" ini:"x_content_type_options"`
+	// +nullable
 	XXssProtection                       *bool  `json:"x_xss_protection,omitempty" ini:"x_xss_protection"`
 }
 
 type GrafanaConfigUsers struct {
+	// +nullable
 	AllowSignUp       *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
+	// +nullable
 	AllowOrgCreate    *bool  `json:"allow_org_create,omitempty" ini:"allow_org_create"`
+	// +nullable
 	AutoAssignOrg     *bool  `json:"auto_assign_org,omitempty" ini:"auto_assign_org"`
 	AutoAssignOrgId   string `json:"auto_assign_org_id,omitempty" ini:"auto_assign_org_id,omitempty"`
 	AutoAssignOrgRole string `json:"auto_assign_org_role,omitempty" ini:"auto_assign_org_role,omitempty"`
+	// +nullable
 	ViewersCanEdit    *bool  `json:"viewers_can_edit,omitempty" ini:"viewers_can_edit"`
+	// +nullable
 	EditorsCanAdmin   *bool  `json:"editors_can_admin,omitempty" ini:"editors_can_admin"`
 	LoginHint         string `json:"login_hint,omitempty" ini:"login_hint,omitempty"`
 	PasswordHint      string `json:"password_hint,omitempty" ini:"password_hint,omitempty"`
@@ -256,31 +284,43 @@ type GrafanaConfigUsers struct {
 
 type GrafanaConfigAuth struct {
 	LoginCookieName                      string `json:"login_cookie_name,omitempty" ini:"login_cookie_name,omitempty"`
+	// +nullable
 	LoginMaximumInactiveLifetimeDays     *int   `json:"login_maximum_inactive_lifetime_days,omitempty" ini:"login_maximum_inactive_lifetime_days,omitempty"`
 	LoginMaximumInactiveLifetimeDuration string `json:"login_maximum_inactive_lifetime_duration,omitempty" ini:"login_maximum_inactive_lifetime_duration,omitempty"`
+	// +nullable
 	LoginMaximumLifetimeDays             *int   `json:"login_maximum_lifetime_days,omitempty" ini:"login_maximum_lifetime_days,omitempty"`
 	LoginMaximumLifetimeDuration         string `json:"login_maximum_lifetime_duration,omitempty" ini:"login_maximum_lifetime_duration,omitempty"`
+	// +nullable
 	TokenRotationIntervalMinutes         *int   `json:"token_rotation_interval_minutes,omitempty" ini:"token_rotation_interval_minutes,omitempty"`
+	// +nullable
 	DisableLoginForm                     *bool  `json:"disable_login_form,omitempty" ini:"disable_login_form"`
+	// +nullable
 	DisableSignoutMenu                   *bool  `json:"disable_signout_menu,omitempty" ini:"disable_signout_menu"`
+	// +nullable
 	SigV4AuthEnabled                     *bool  `json:"sigv4_auth_enabled,omitempty" ini:"sigv4_auth_enabled"`
 	SignoutRedirectUrl                   string `json:"signout_redirect_url,omitempty" ini:"signout_redirect_url,omitempty"`
+	// +nullable
 	OauthAutoLogin                       *bool  `json:"oauth_auto_login,omitempty" ini:"oauth_auto_login"`
 }
 
 type GrafanaConfigAuthBasic struct {
+	// +nullable
 	Enabled *bool `json:"enabled,omitempty" ini:"enabled"`
 }
 
 type GrafanaConfigAuthAnonymous struct {
+	// +nullable
 	Enabled *bool  `json:"enabled,omitempty" ini:"enabled"`
 	OrgName string `json:"org_name,omitempty" ini:"org_name,omitempty"`
 	OrgRole string `json:"org_role,omitempty" ini:"org_role,omitempty"`
 }
 
 type GrafanaConfigAuthSaml struct {
+	// +nullable
 	Enabled                  *bool  `json:"enabled,omitempty" ini:"enabled"`
+	// +nullable
 	SingleLogout             *bool  `json:"single_logout,omitempty" ini:"single_logout,omitempty"`
+	// +nullable
 	AllowIdpInitiated        *bool  `json:"allow_idp_initiated,omitempty" ini:"allow_idp_initiated,omitempty"`
 	CertificatePath          string `json:"certificate_path,omitempty" ini:"certificate_path"`
 	KeyPath                  string `json:"private_key_path,omitempty" ini:"private_key_path"`
@@ -303,7 +343,9 @@ type GrafanaConfigAuthSaml struct {
 }
 
 type GrafanaConfigAuthAzureAD struct {
+	// +nullable
 	Enabled        *bool  `json:"enabled,omitempty" ini:"enabled"`
+	// +nullable
 	AllowSignUp    *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId       string `json:"client_id,omitempty" ini:"client_id,omitempty"`
 	ClientSecret   string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
@@ -315,6 +357,7 @@ type GrafanaConfigAuthAzureAD struct {
 }
 
 type GrafanaConfigAuthGoogle struct {
+	// +nullable
 	Enabled        *bool  `json:"enabled,omitempty" ini:"enabled"`
 	ClientId       string `json:"client_id,omitempty" ini:"client_id,omitempty"`
 	ClientSecret   string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
@@ -326,7 +369,9 @@ type GrafanaConfigAuthGoogle struct {
 }
 
 type GrafanaConfigAuthGithub struct {
+	// +nullable
 	Enabled              *bool  `json:"enabled,omitempty" ini:"enabled"`
+	// +nullable
 	AllowSignUp          *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId             string `json:"client_id,omitempty" ini:"client_id,omitempty"`
 	ClientSecret         string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
@@ -339,7 +384,9 @@ type GrafanaConfigAuthGithub struct {
 }
 
 type GrafanaConfigAuthGitlab struct {
+	// +nullable
 	Enabled       *bool  `json:"enabled,omitempty" ini:"enabled"`
+	// +nullable
 	AllowSignUp   *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId      string `json:"client_id,omitempty" ini:"client_id,omitempty"`
 	ClientSecret  string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
@@ -351,7 +398,9 @@ type GrafanaConfigAuthGitlab struct {
 }
 
 type GrafanaConfigAuthGenericOauth struct {
+	// +nullable
 	Enabled               *bool  `json:"enabled,omitempty" ini:"enabled"`
+	// +nullable
 	AllowSignUp           *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId              string `json:"client_id,omitempty" ini:"client_id,omitempty"`
 	ClientSecret          string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
@@ -361,8 +410,10 @@ type GrafanaConfigAuthGenericOauth struct {
 	ApiUrl                string `json:"api_url,omitempty" ini:"api_url,omitempty"`
 	AllowedDomains        string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
 	RoleAttributePath     string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	// +nullable
 	RoleAttributeStrict   *bool  `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
 	EmailAttributePath    string `json:"email_attribute_path,omitempty" ini:"email_attribute_path,omitempty"`
+	// +nullable
 	TLSSkipVerifyInsecure *bool  `json:"tls_skip_verify_insecure,omitempty" ini:"tls_skip_verify_insecure,omitempty"`
 	TLSClientCert         string `json:"tls_client_cert,omitempty" ini:"tls_client_cert,omitempty"`
 	TLSClientKey          string `json:"tls_client_key,omitempty" ini:"tls_client_key,omitempty"`
@@ -370,8 +421,10 @@ type GrafanaConfigAuthGenericOauth struct {
 }
 
 type GrafanaConfigAuthOkta struct {
+	// +nullable
 	Enabled             *bool  `json:"enabled,omitempty" ini:"enabled"`
 	Name                string `json:"name,omitempty" ini:"name,omitempty"`
+	// +nullable
 	AllowSignUp         *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ClientId            string `json:"client_id,omitempty" ini:"client_id,omitempty"`
 	ClientSecret        string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
@@ -382,49 +435,63 @@ type GrafanaConfigAuthOkta struct {
 	AllowedDomains      string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
 	AllowedGroups       string `json:"allowed_groups,omitempty" ini:"allowed_groups,omitempty"`
 	RoleAttributePath   string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	// +nullable
 	RoleAttributeStrict *bool  `json:"role_attribute_strict,omitempty" ini:"role_attribute_strict,omitempty"`
 }
 
 type GrafanaConfigAuthLdap struct {
+	// +nullable
 	Enabled     *bool  `json:"enabled,omitempty" ini:"enabled"`
+	// +nullable
 	AllowSignUp *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
 	ConfigFile  string `json:"config_file,omitempty" ini:"config_file,omitempty"`
 }
 
 type GrafanaConfigAuthProxy struct {
+	// +nullable
 	Enabled          *bool  `json:"enabled,omitempty" ini:"enabled"`
 	HeaderName       string `json:"header_name,omitempty" ini:"header_name,omitempty"`
 	HeaderProperty   string `json:"header_property,omitempty" ini:"header_property,omitempty"`
+	// +nullable
 	AutoSignUp       *bool  `json:"auto_sign_up,omitempty" ini:"auto_sign_up"`
 	LdapSyncTtl      string `json:"ldap_sync_ttl,omitempty" ini:"ldap_sync_ttl,omitempty"`
 	Whitelist        string `json:"whitelist,omitempty" ini:"whitelist,omitempty"`
 	Headers          string `json:"headers,omitempty" ini:"headers,omitempty"`
+	// +nullable
 	EnableLoginToken *bool  `json:"enable_login_token,omitempty" ini:"enable_login_token"`
 }
 
 type GrafanaConfigDataProxy struct {
+	// +nullable
 	Logging        *bool `json:"logging,omitempty" ini:"logging"`
+	// +nullable
 	Timeout        *int  `json:"timeout,omitempty" ini:"timeout,omitempty"`
+	// +nullable
 	SendUserHeader *bool `json:"send_user_header,omitempty" ini:"send_user_header,omitempty"`
 }
 
 type GrafanaConfigAnalytics struct {
+	// +nullable
 	ReportingEnabled    *bool  `json:"reporting_enabled,omitempty" ini:"reporting_enabled"`
 	GoogleAnalyticsUaId string `json:"google_analytics_ua_id,omitempty" ini:"google_analytics_ua_id,omitempty"`
+	// +nullable
 	CheckForUpdates     *bool  `json:"check_for_updates,omitempty" ini:"check_for_updates"`
 }
 
 type GrafanaConfigDashboards struct {
+	// +nullable
 	VersionsToKeep *int `json:"versions_to_keep,omitempty" ini:"versions_to_keep,omitempty"`
 }
 
 type GrafanaConfigSmtp struct {
+	// +nullable
 	Enabled      *bool  `json:"enabled,omitempty" ini:"enabled"`
 	Host         string `json:"host,omitempty" ini:"host,omitempty"`
 	User         string `json:"user,omitempty" ini:"user,omitempty"`
 	Password     string `json:"password,omitempty" ini:"password,omitempty"`
 	CertFile     string `json:"cert_file,omitempty" ini:"cert_file,omitempty"`
 	KeyFile      string `json:"key_file,omitempty" ini:"key_file,omitempty"`
+	// +nullable
 	SkipVerify   *bool  `json:"skip_verify,omitempty" ini:"skip_verify"`
 	FromAddress  string `json:"from_address,omitempty" ini:"from_address,omitempty"`
 	FromName     string `json:"from_name,omitempty" ini:"from_name,omitempty"`
@@ -432,6 +499,7 @@ type GrafanaConfigSmtp struct {
 }
 
 type GrafanaConfigLive struct {
+	// +nullable
 	MaxConnections *int   `json:"max_connections,omitempty" ini:"max_connections,omitempty"`
 	AllowedOrigins string `json:"allowed_origins,omitempty" ini:"allowed_origins,omitempty"`
 }
@@ -443,11 +511,14 @@ type GrafanaConfigLog struct {
 }
 
 type GrafanaConfigLogFrontend struct {
+	// +nullable
 	Enabled                           *bool  `json:"enabled,omitempty" ini:"enabled,omitempty"`
 	SentryDsn                         string `json:"sentry_dsn,omitempty" ini:"sentry_dsn,omitempty"`
 	CustomEndpoint                    string `json:"custom_endpoint,omitempty" ini:"custom_endpoint,omitempty"`
 	SampleRate                        string `json:"sample_rate,omitempty" ini:"sample_rate,omitempty"`
+	// +nullable
 	LogEndpointRequestsPerSecondLimit *int   `json:"log_endpoint_requests_per_second_limit,omitempty" ini:"log_endpoint_requests_per_second_limit,omitempty"`
+	// +nullable
 	LogEndpointBurstLimit             *int   `json:"log_endpoint_burst_limit,omitempty" ini:"log_endpoint_burst_limit,omitempty"`
 }
 
@@ -457,9 +528,11 @@ type GrafanaConfigLogConsole struct {
 }
 
 type GrafanaConfigMetrics struct {
+	// +nullable
 	Enabled           *bool  `json:"enabled,omitempty" ini:"enabled"`
 	BasicAuthUsername string `json:"basic_auth_username,omitempty" ini:"basic_auth_username,omitempty"`
 	BasicAuthPassword string `json:"basic_auth_password,omitempty" ini:"basic_auth_password,omitempty"`
+	// +nullable
 	IntervalSeconds   *int   `json:"interval_seconds,omitempty" ini:"interval_seconds,omitempty"`
 }
 
@@ -469,9 +542,11 @@ type GrafanaConfigMetricsGraphite struct {
 }
 
 type GrafanaConfigSnapshots struct {
+	// +nullable
 	ExternalEnabled       *bool  `json:"external_enabled,omitempty" ini:"external_enabled"`
 	ExternalSnapshotUrl   string `json:"external_snapshot_url,omitempty" ini:"external_snapshot_url,omitempty"`
 	ExternalSnapshotName  string `json:"external_snapshot_name,omitempty" ini:"external_snapshot_name,omitempty"`
+	// +nullable
 	SnapshotRemoveExpired *bool  `json:"snapshot_remove_expired,omitempty" ini:"snapshot_remove_expired"`
 }
 
@@ -508,27 +583,36 @@ type GrafanaConfigExternalImageStorageAzureBlob struct {
 }
 
 type GrafanaConfigAlerting struct {
+	// +nullable
 	Enabled                    *bool  `json:"enabled,omitempty" ini:"enabled"`
+	// +nullable
 	ExecuteAlerts              *bool  `json:"execute_alerts,omitempty" ini:"execute_alerts"`
 	ErrorOrTimeout             string `json:"error_or_timeout,omitempty" ini:"error_or_timeout,omitempty"`
 	NodataOrNullvalues         string `json:"nodata_or_nullvalues,omitempty" ini:"nodata_or_nullvalues,omitempty"`
+	// +nullable
 	ConcurrentRenderLimit      *int   `json:"concurrent_render_limit,omitempty" ini:"concurrent_render_limit,omitempty"`
+	// +nullable
 	EvaluationTimeoutSeconds   *int   `json:"evaluation_timeout_seconds,omitempty" ini:"evaluation_timeout_seconds,omitempty"`
+	// +nullable
 	NotificationTimeoutSeconds *int   `json:"notification_timeout_seconds,omitempty" ini:"notification_timeout_seconds,omitempty"`
+	// +nullable
 	MaxAttempts                *int   `json:"max_attempts,omitempty" ini:"max_attempts,omitempty"`
 }
 
 type GrafanaConfigPanels struct {
+	// +nullable
 	DisableSanitizeHtml *bool `json:"disable_sanitize_html,omitempty" ini:"disable_sanitize_html"`
 }
 
 type GrafanaConfigPlugins struct {
+	// +nullable
 	EnableAlpha *bool `json:"enable_alpha,omitempty" ini:"enable_alpha"`
 }
 
 type GrafanaConfigRendering struct {
 	ServerURL                    string `json:"server_url,omitempty" ini:"server_url"`
 	CallbackURL                  string `json:"callback_url,omitempty" ini:"callback_url"`
+	// +nullable
 	ConcurrentRenderRequestLimit *int   `json:"concurrent_render_request_limit,omitempty" ini:"concurrent_render_request_limit,omitempty"`
 }
 
@@ -541,8 +625,11 @@ type GrafanaStatus struct {
 	Phase               StatusPhase            `json:"phase,omitempty"`
 	PreviousServiceName string                 `json:"previousServiceName,omitempty"`
 	Message             string                 `json:"message,omitempty"`
+	// +nullable
 	InstalledDashboards []*GrafanaDashboardRef `json:"dashboards,omitempty"`
+	// +nullable
 	InstalledPlugins    PluginList             `json:"installedPlugins,omitempty"`
+	// +nullable
 	FailedPlugins       PluginList             `json:"failedPlugins,omitempty"`
 }
 

--- a/bundle/manifests/integreatly.org_grafanadashboards.yaml
+++ b/bundle/manifests/integreatly.org_grafanadashboards.yaml
@@ -59,6 +59,15 @@ spec:
                   - inputName
                   type: object
                 type: array
+              grafanaCom:
+                properties:
+                  id:
+                    type: integer
+                  revision:
+                    type: integer
+                required:
+                - id
+                type: object
               json:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
                 type: string

--- a/bundle/manifests/integreatly.org_grafanadatasources.yaml
+++ b/bundle/manifests/integreatly.org_grafanadatasources.yaml
@@ -70,6 +70,8 @@ spec:
                           type: string
                         cloudName:
                           type: string
+                        clusterUrl:
+                          type: string
                         connMaxLifetime:
                           type: integer
                         customMetricsNamespaces:
@@ -176,6 +178,20 @@ spec:
                         tokenUri:
                           description: Fields for Stackdriver data sources
                           type: string
+                        tracesToLogs:
+                          description: Fields for tracing data sources
+                          properties:
+                            datasourceUid:
+                              type: string
+                            spanEndTimeShift:
+                              type: string
+                            spanStartTimeShift:
+                              type: string
+                            tags:
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         tsdbResolution:
                           type: string
                         tsdbVersion:

--- a/bundle/manifests/integreatly.org_grafanas.yaml
+++ b/bundle/manifests/integreatly.org_grafanas.yaml
@@ -35,8 +35,10 @@ spec:
                 description: Grafana API client settings
                 properties:
                   preferService:
+                    nullable: true
                     type: boolean
                   timeout:
+                    nullable: true
                     type: integer
                 type: object
               config:
@@ -45,59 +47,75 @@ spec:
                   alerting:
                     properties:
                       concurrent_render_limit:
+                        nullable: true
                         type: integer
                       enabled:
+                        nullable: true
                         type: boolean
                       error_or_timeout:
                         type: string
                       evaluation_timeout_seconds:
+                        nullable: true
                         type: integer
                       execute_alerts:
+                        nullable: true
                         type: boolean
                       max_attempts:
+                        nullable: true
                         type: integer
                       nodata_or_nullvalues:
                         type: string
                       notification_timeout_seconds:
+                        nullable: true
                         type: integer
                     type: object
                   analytics:
                     properties:
                       check_for_updates:
+                        nullable: true
                         type: boolean
                       google_analytics_ua_id:
                         type: string
                       reporting_enabled:
+                        nullable: true
                         type: boolean
                     type: object
                   auth:
                     properties:
                       disable_login_form:
+                        nullable: true
                         type: boolean
                       disable_signout_menu:
+                        nullable: true
                         type: boolean
                       login_cookie_name:
                         type: string
                       login_maximum_inactive_lifetime_days:
+                        nullable: true
                         type: integer
                       login_maximum_inactive_lifetime_duration:
                         type: string
                       login_maximum_lifetime_days:
+                        nullable: true
                         type: integer
                       login_maximum_lifetime_duration:
                         type: string
                       oauth_auto_login:
+                        nullable: true
                         type: boolean
                       signout_redirect_url:
                         type: string
                       sigv4_auth_enabled:
+                        nullable: true
                         type: boolean
                       token_rotation_interval_minutes:
+                        nullable: true
                         type: integer
                     type: object
                   auth.anonymous:
                     properties:
                       enabled:
+                        nullable: true
                         type: boolean
                       org_name:
                         type: string
@@ -107,6 +125,7 @@ spec:
                   auth.azuread:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_domains:
                         type: string
@@ -119,6 +138,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -128,11 +148,13 @@ spec:
                   auth.basic:
                     properties:
                       enabled:
+                        nullable: true
                         type: boolean
                     type: object
                   auth.generic_oauth:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_domains:
                         type: string
@@ -147,10 +169,12 @@ spec:
                       email_attribute_path:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       role_attribute_path:
                         type: string
                       role_attribute_strict:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -161,6 +185,7 @@ spec:
                       tls_client_key:
                         type: string
                       tls_skip_verify_insecure:
+                        nullable: true
                         type: boolean
                       token_url:
                         type: string
@@ -168,6 +193,7 @@ spec:
                   auth.github:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_organizations:
                         type: string
@@ -180,6 +206,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -191,6 +218,7 @@ spec:
                   auth.gitlab:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_groups:
                         type: string
@@ -203,6 +231,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -222,6 +251,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -231,15 +261,18 @@ spec:
                   auth.ldap:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       config_file:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                     type: object
                   auth.okta:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_domains:
                         type: string
@@ -254,12 +287,14 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       name:
                         type: string
                       role_attribute_path:
                         type: string
                       role_attribute_strict:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -269,10 +304,13 @@ spec:
                   auth.proxy:
                     properties:
                       auto_sign_up:
+                        nullable: true
                         type: boolean
                       enable_login_token:
+                        nullable: true
                         type: boolean
                       enabled:
+                        nullable: true
                         type: boolean
                       header_name:
                         type: string
@@ -288,6 +326,7 @@ spec:
                   auth.saml:
                     properties:
                       allow_idp_initiated:
+                        nullable: true
                         type: boolean
                       allowed_organizations:
                         type: string
@@ -306,6 +345,7 @@ spec:
                       certificate_path:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       idp_metadata_url:
                         type: string
@@ -328,11 +368,13 @@ spec:
                       signature_algorithm:
                         type: string
                       single_logout:
+                        nullable: true
                         type: boolean
                     type: object
                   dashboards:
                     properties:
                       versions_to_keep:
+                        nullable: true
                         type: integer
                     type: object
                   database:
@@ -346,14 +388,18 @@ spec:
                       client_key_path:
                         type: string
                       conn_max_lifetime:
+                        nullable: true
                         type: integer
                       host:
                         type: string
                       log_queries:
+                        nullable: true
                         type: boolean
                       max_idle_conn:
+                        nullable: true
                         type: integer
                       max_open_conn:
+                        nullable: true
                         type: integer
                       name:
                         type: string
@@ -375,10 +421,13 @@ spec:
                   dataproxy:
                     properties:
                       logging:
+                        nullable: true
                         type: boolean
                       send_user_header:
+                        nullable: true
                         type: boolean
                       timeout:
+                        nullable: true
                         type: integer
                     type: object
                   external_image_storage:
@@ -435,6 +484,14 @@ spec:
                       enable:
                         type: string
                     type: object
+                  live:
+                    properties:
+                      allowed_origins:
+                        type: string
+                      max_connections:
+                        nullable: true
+                        type: integer
+                    type: object
                   log:
                     properties:
                       filters:
@@ -456,10 +513,13 @@ spec:
                       custom_endpoint:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       log_endpoint_burst_limit:
+                        nullable: true
                         type: integer
                       log_endpoint_requests_per_second_limit:
+                        nullable: true
                         type: integer
                       sample_rate:
                         type: string
@@ -473,8 +533,10 @@ spec:
                       basic_auth_username:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       interval_seconds:
+                        nullable: true
                         type: integer
                     type: object
                   metrics.graphite:
@@ -487,6 +549,7 @@ spec:
                   panels:
                     properties:
                       disable_sanitize_html:
+                        nullable: true
                         type: boolean
                     type: object
                   paths:
@@ -497,6 +560,7 @@ spec:
                   plugins:
                     properties:
                       enable_alpha:
+                        nullable: true
                         type: boolean
                     type: object
                   remote_cache:
@@ -511,6 +575,7 @@ spec:
                       callback_url:
                         type: string
                       concurrent_render_request_limit:
+                        nullable: true
                         type: integer
                       server_url:
                         type: string
@@ -522,30 +587,40 @@ spec:
                       admin_user:
                         type: string
                       allow_embedding:
+                        nullable: true
                         type: boolean
                       cookie_samesite:
                         type: string
                       cookie_secure:
+                        nullable: true
                         type: boolean
                       data_source_proxy_whitelist:
                         type: string
                       disable_gravatar:
+                        nullable: true
                         type: boolean
                       login_remember_days:
+                        nullable: true
                         type: integer
                       secret_key:
                         type: string
                       strict_transport_security:
+                        nullable: true
                         type: boolean
                       strict_transport_security_max_age_seconds:
+                        nullable: true
                         type: integer
                       strict_transport_security_preload:
+                        nullable: true
                         type: boolean
                       strict_transport_security_subdomains:
+                        nullable: true
                         type: boolean
                       x_content_type_options:
+                        nullable: true
                         type: boolean
                       x_xss_protection:
+                        nullable: true
                         type: boolean
                     type: object
                   server:
@@ -557,8 +632,10 @@ spec:
                       domain:
                         type: string
                       enable_gzip:
+                        nullable: true
                         type: boolean
                       enforce_domain:
+                        nullable: true
                         type: boolean
                       http_addr:
                         type: string
@@ -569,8 +646,10 @@ spec:
                       root_url:
                         type: string
                       router_logging:
+                        nullable: true
                         type: boolean
                       serve_from_sub_path:
+                        nullable: true
                         type: boolean
                       socket:
                         type: string
@@ -584,6 +663,7 @@ spec:
                       ehlo_identity:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       from_address:
                         type: string
@@ -596,6 +676,7 @@ spec:
                       password:
                         type: string
                       skip_verify:
+                        nullable: true
                         type: boolean
                       user:
                         type: string
@@ -603,21 +684,26 @@ spec:
                   snapshots:
                     properties:
                       external_enabled:
+                        nullable: true
                         type: boolean
                       external_snapshot_name:
                         type: string
                       external_snapshot_url:
                         type: string
                       snapshot_remove_expired:
+                        nullable: true
                         type: boolean
                     type: object
                   users:
                     properties:
                       allow_org_create:
+                        nullable: true
                         type: boolean
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       auto_assign_org:
+                        nullable: true
                         type: boolean
                       auto_assign_org_id:
                         type: string
@@ -626,12 +712,14 @@ spec:
                       default_theme:
                         type: string
                       editors_can_admin:
+                        nullable: true
                         type: boolean
                       login_hint:
                         type: string
                       password_hint:
                         type: string
                       viewers_can_edit:
+                        nullable: true
                         type: boolean
                     type: object
                 type: object
@@ -2920,6 +3008,7 @@ spec:
                       type: object
                     type: array
                   hostNetwork:
+                    nullable: true
                     type: boolean
                   httpProxy:
                     description: GrafanaHttpProxy provides a means to configure the Grafana deployment to use a HTTP(S) proxy when making requests and resolving plugins.
@@ -2943,6 +3032,7 @@ spec:
                     type: string
                   replicas:
                     format: int32
+                    nullable: true
                     type: integer
                   securityContext:
                     description: PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
@@ -3030,6 +3120,7 @@ spec:
                         type: object
                     type: object
                   skipCreateAdminAccount:
+                    nullable: true
                     type: boolean
                   strategy:
                     description: DeploymentStrategy describes how to replace existing pods with new ones.
@@ -3334,6 +3425,7 @@ spec:
                   - namespace
                   - uid
                   type: object
+                nullable: true
                 type: array
               failedPlugins:
                 items:
@@ -3347,6 +3439,7 @@ spec:
                   - name
                   - version
                   type: object
+                nullable: true
                 type: array
               installedPlugins:
                 items:
@@ -3360,6 +3453,7 @@ spec:
                   - name
                   - version
                   type: object
+                nullable: true
                 type: array
               message:
                 type: string

--- a/config/crd/bases/integreatly.org_grafanas.yaml
+++ b/config/crd/bases/integreatly.org_grafanas.yaml
@@ -41,8 +41,10 @@ spec:
                 description: Grafana API client settings
                 properties:
                   preferService:
+                    nullable: true
                     type: boolean
                   timeout:
+                    nullable: true
                     type: integer
                 type: object
               config:
@@ -51,59 +53,75 @@ spec:
                   alerting:
                     properties:
                       concurrent_render_limit:
+                        nullable: true
                         type: integer
                       enabled:
+                        nullable: true
                         type: boolean
                       error_or_timeout:
                         type: string
                       evaluation_timeout_seconds:
+                        nullable: true
                         type: integer
                       execute_alerts:
+                        nullable: true
                         type: boolean
                       max_attempts:
+                        nullable: true
                         type: integer
                       nodata_or_nullvalues:
                         type: string
                       notification_timeout_seconds:
+                        nullable: true
                         type: integer
                     type: object
                   analytics:
                     properties:
                       check_for_updates:
+                        nullable: true
                         type: boolean
                       google_analytics_ua_id:
                         type: string
                       reporting_enabled:
+                        nullable: true
                         type: boolean
                     type: object
                   auth:
                     properties:
                       disable_login_form:
+                        nullable: true
                         type: boolean
                       disable_signout_menu:
+                        nullable: true
                         type: boolean
                       login_cookie_name:
                         type: string
                       login_maximum_inactive_lifetime_days:
+                        nullable: true
                         type: integer
                       login_maximum_inactive_lifetime_duration:
                         type: string
                       login_maximum_lifetime_days:
+                        nullable: true
                         type: integer
                       login_maximum_lifetime_duration:
                         type: string
                       oauth_auto_login:
+                        nullable: true
                         type: boolean
                       signout_redirect_url:
                         type: string
                       sigv4_auth_enabled:
+                        nullable: true
                         type: boolean
                       token_rotation_interval_minutes:
+                        nullable: true
                         type: integer
                     type: object
                   auth.anonymous:
                     properties:
                       enabled:
+                        nullable: true
                         type: boolean
                       org_name:
                         type: string
@@ -113,6 +131,7 @@ spec:
                   auth.azuread:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_domains:
                         type: string
@@ -125,6 +144,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -134,11 +154,13 @@ spec:
                   auth.basic:
                     properties:
                       enabled:
+                        nullable: true
                         type: boolean
                     type: object
                   auth.generic_oauth:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_domains:
                         type: string
@@ -153,10 +175,12 @@ spec:
                       email_attribute_path:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       role_attribute_path:
                         type: string
                       role_attribute_strict:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -167,6 +191,7 @@ spec:
                       tls_client_key:
                         type: string
                       tls_skip_verify_insecure:
+                        nullable: true
                         type: boolean
                       token_url:
                         type: string
@@ -174,6 +199,7 @@ spec:
                   auth.github:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_organizations:
                         type: string
@@ -186,6 +212,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -197,6 +224,7 @@ spec:
                   auth.gitlab:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_groups:
                         type: string
@@ -209,6 +237,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -228,6 +257,7 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -237,15 +267,18 @@ spec:
                   auth.ldap:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       config_file:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                     type: object
                   auth.okta:
                     properties:
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       allowed_domains:
                         type: string
@@ -260,12 +293,14 @@ spec:
                       client_secret:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       name:
                         type: string
                       role_attribute_path:
                         type: string
                       role_attribute_strict:
+                        nullable: true
                         type: boolean
                       scopes:
                         type: string
@@ -275,10 +310,13 @@ spec:
                   auth.proxy:
                     properties:
                       auto_sign_up:
+                        nullable: true
                         type: boolean
                       enable_login_token:
+                        nullable: true
                         type: boolean
                       enabled:
+                        nullable: true
                         type: boolean
                       header_name:
                         type: string
@@ -294,6 +332,7 @@ spec:
                   auth.saml:
                     properties:
                       allow_idp_initiated:
+                        nullable: true
                         type: boolean
                       allowed_organizations:
                         type: string
@@ -312,6 +351,7 @@ spec:
                       certificate_path:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       idp_metadata_url:
                         type: string
@@ -334,11 +374,13 @@ spec:
                       signature_algorithm:
                         type: string
                       single_logout:
+                        nullable: true
                         type: boolean
                     type: object
                   dashboards:
                     properties:
                       versions_to_keep:
+                        nullable: true
                         type: integer
                     type: object
                   database:
@@ -352,14 +394,18 @@ spec:
                       client_key_path:
                         type: string
                       conn_max_lifetime:
+                        nullable: true
                         type: integer
                       host:
                         type: string
                       log_queries:
+                        nullable: true
                         type: boolean
                       max_idle_conn:
+                        nullable: true
                         type: integer
                       max_open_conn:
+                        nullable: true
                         type: integer
                       name:
                         type: string
@@ -381,10 +427,13 @@ spec:
                   dataproxy:
                     properties:
                       logging:
+                        nullable: true
                         type: boolean
                       send_user_header:
+                        nullable: true
                         type: boolean
                       timeout:
+                        nullable: true
                         type: integer
                     type: object
                   external_image_storage:
@@ -446,6 +495,7 @@ spec:
                       allowed_origins:
                         type: string
                       max_connections:
+                        nullable: true
                         type: integer
                     type: object
                   log:
@@ -469,10 +519,13 @@ spec:
                       custom_endpoint:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       log_endpoint_burst_limit:
+                        nullable: true
                         type: integer
                       log_endpoint_requests_per_second_limit:
+                        nullable: true
                         type: integer
                       sample_rate:
                         type: string
@@ -486,8 +539,10 @@ spec:
                       basic_auth_username:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       interval_seconds:
+                        nullable: true
                         type: integer
                     type: object
                   metrics.graphite:
@@ -500,6 +555,7 @@ spec:
                   panels:
                     properties:
                       disable_sanitize_html:
+                        nullable: true
                         type: boolean
                     type: object
                   paths:
@@ -510,6 +566,7 @@ spec:
                   plugins:
                     properties:
                       enable_alpha:
+                        nullable: true
                         type: boolean
                     type: object
                   remote_cache:
@@ -524,6 +581,7 @@ spec:
                       callback_url:
                         type: string
                       concurrent_render_request_limit:
+                        nullable: true
                         type: integer
                       server_url:
                         type: string
@@ -535,30 +593,40 @@ spec:
                       admin_user:
                         type: string
                       allow_embedding:
+                        nullable: true
                         type: boolean
                       cookie_samesite:
                         type: string
                       cookie_secure:
+                        nullable: true
                         type: boolean
                       data_source_proxy_whitelist:
                         type: string
                       disable_gravatar:
+                        nullable: true
                         type: boolean
                       login_remember_days:
+                        nullable: true
                         type: integer
                       secret_key:
                         type: string
                       strict_transport_security:
+                        nullable: true
                         type: boolean
                       strict_transport_security_max_age_seconds:
+                        nullable: true
                         type: integer
                       strict_transport_security_preload:
+                        nullable: true
                         type: boolean
                       strict_transport_security_subdomains:
+                        nullable: true
                         type: boolean
                       x_content_type_options:
+                        nullable: true
                         type: boolean
                       x_xss_protection:
+                        nullable: true
                         type: boolean
                     type: object
                   server:
@@ -570,8 +638,10 @@ spec:
                       domain:
                         type: string
                       enable_gzip:
+                        nullable: true
                         type: boolean
                       enforce_domain:
+                        nullable: true
                         type: boolean
                       http_addr:
                         type: string
@@ -582,8 +652,10 @@ spec:
                       root_url:
                         type: string
                       router_logging:
+                        nullable: true
                         type: boolean
                       serve_from_sub_path:
+                        nullable: true
                         type: boolean
                       socket:
                         type: string
@@ -597,6 +669,7 @@ spec:
                       ehlo_identity:
                         type: string
                       enabled:
+                        nullable: true
                         type: boolean
                       from_address:
                         type: string
@@ -609,6 +682,7 @@ spec:
                       password:
                         type: string
                       skip_verify:
+                        nullable: true
                         type: boolean
                       user:
                         type: string
@@ -616,21 +690,26 @@ spec:
                   snapshots:
                     properties:
                       external_enabled:
+                        nullable: true
                         type: boolean
                       external_snapshot_name:
                         type: string
                       external_snapshot_url:
                         type: string
                       snapshot_remove_expired:
+                        nullable: true
                         type: boolean
                     type: object
                   users:
                     properties:
                       allow_org_create:
+                        nullable: true
                         type: boolean
                       allow_sign_up:
+                        nullable: true
                         type: boolean
                       auto_assign_org:
+                        nullable: true
                         type: boolean
                       auto_assign_org_id:
                         type: string
@@ -639,12 +718,14 @@ spec:
                       default_theme:
                         type: string
                       editors_can_admin:
+                        nullable: true
                         type: boolean
                       login_hint:
                         type: string
                       password_hint:
                         type: string
                       viewers_can_edit:
+                        nullable: true
                         type: boolean
                     type: object
                 type: object
@@ -4298,6 +4379,7 @@ spec:
                       type: object
                     type: array
                   hostNetwork:
+                    nullable: true
                     type: boolean
                   httpProxy:
                     description: GrafanaHttpProxy provides a means to configure the
@@ -4323,6 +4405,7 @@ spec:
                     type: string
                   replicas:
                     format: int32
+                    nullable: true
                     type: integer
                   securityContext:
                     description: PodSecurityContext holds pod-level security attributes
@@ -4475,6 +4558,7 @@ spec:
                         type: object
                     type: object
                   skipCreateAdminAccount:
+                    nullable: true
                     type: boolean
                   strategy:
                     description: DeploymentStrategy describes how to replace existing
@@ -4885,6 +4969,7 @@ spec:
                   - namespace
                   - uid
                   type: object
+                nullable: true
                 type: array
               failedPlugins:
                 items:
@@ -4898,6 +4983,7 @@ spec:
                   - name
                   - version
                   type: object
+                nullable: true
                 type: array
               installedPlugins:
                 items:
@@ -4911,6 +4997,7 @@ spec:
                   - name
                   - version
                   type: object
+                nullable: true
                 type: array
               message:
                 type: string


### PR DESCRIPTION
Improve the bundle CRDs by adding nullable to all non-struct pointer fields. When running the v3.10.x, some of the fields in the CR get set to `null` when only partially specifying a config struct. Those fields can't be parsed when they are not set to nullable and cause a validation error when upgrading the CRD.