### PR TITLE
Issue #487: set default ingress path 

### DIFF
--- a/controllers/model/grafanaRoute.go
+++ b/controllers/model/grafanaRoute.go
@@ -20,6 +20,11 @@ func GetPath(cr *v1alpha1.Grafana) string {
 	if cr.Spec.Ingress == nil {
 		return "/"
 	}
+
+	if cr.Spec.Ingress.Path == "" {
+		return "/"
+	}
+
 	return cr.Spec.Ingress.Path
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
Sets default path (/) when creating an ingress and no explicit path is set by user
## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
https://github.com/grafana-operator/grafana-operator/issues/487
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
* Operator deployed locally with using example Grafana instance with `path: " "` in `spec.ingress`
* Grafana ingress object should contain default path of `path: /`