### PR TITLE
Add rules for GrafanaNotificationChannel to ClusterRole manager-role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -96,6 +96,26 @@ rules:
 - apiGroups:
   - integreatly.org
   resources:
+  - grafananotificationchannels
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafananotificationchannels/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - integreatly.org
+  resources:
   - grafanas
   - grafanas/finalizers
   verbs:

--- a/controllers/grafananotificationchannel/grafananotificationchannel_controller.go
+++ b/controllers/grafananotificationchannel/grafananotificationchannel_controller.go
@@ -50,8 +50,6 @@ const (
 	ControllerName = "controller_grafananotificationchannel"
 )
 
-// +kubebuilder:rbac:groups=integreatly.org,resources=grafananotificationchannels,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=integreatly.org,resources=grafananotificationchannels/status,verbs=get;update;patch
 type GrafanaChannel struct {
 	ID                    *uint   `json:"id"`
 	UID                   *string `json:"uid"`
@@ -89,6 +87,10 @@ func Add(mgr manager.Manager, namespace string) error {
 	return SetupWithManager(mgr, NewReconciler(mgr), namespace)
 }
 
+// +kubebuilder:rbac:groups=integreatly.org,resources=grafananotificationchannels,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=integreatly.org,resources=grafananotificationchannels/status,verbs=get;update;patch
+
+// SetupWithManager sets up the controller with the Manager.
 func SetupWithManager(mgr ctrl.Manager, r reconcile.Reconciler, namespace string) error {
 	c, err := controller.New("grafananotificationchannel-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {


### PR DESCRIPTION
## Description
GrafanaNotificationChannel was added to master. Deploying operator via `kustomize build config/install |kubectl apply -f -
`, the operator logs the following error:

```
E0929 06:59:09.118594       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.GrafanaNotificationChannel: failed to list *v1alpha1.GrafanaNotificationChannel: grafananotificationchannels.integreatly.org is forbidden: User "system:serviceaccount:grafana-operator-system:default" cannot list resource "grafananotificationchannels" in API group "integreatly.org" in the namespace "grafana-operator-system"
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
- Deploy fresh operator following supplied documentation on current master to note the error.
- Modify the manager-role and add rules for the grafananotificationchannel resource to resolve errors
