### PR TITLE
CHORE: updates README.md to link to existing development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ operator-sdk build <registry>/<user>/grafana-operator:<tag>
 
 ## Running locally
 
+### Using the Makefile
+If you want to further develop the operator, here are some instructions how to set up your dev-environment: [follow me](./documentation/develop.md)
+
+### Using operator-sdk (not supported anymore by operator-sdk)
 You can run the Operator locally against a remote namespace using the operator-sdk:
 
 Prerequisites:


### PR DESCRIPTION
## Description
The readme.md still referenced the "old way" of using `operator-sdk run local`.
This way is not supported anymore by the operator-sdk
Fortunately there was already a documentation present. This PR links the documentation to the "main" readme.

## Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue