### PR TITLE
#585: changes image to current version in deploy of operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: grafana-operator
       containers:
         - name: grafana-operator
-          image: quay.io/integreatly/grafana-operator:v4.0.0
+          image: quay.io/grafana-operator/grafana-operator:v4.0.1
           ports:
             - containerPort: 60000
               name: metrics


### PR DESCRIPTION
## Description
The referenced Image was never build.
This PR adds the correct one, so if anyone would try to deploy it, he would not fail to do so.

## Relevant issues/tickets
#585 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Verification steps
- spin a Kubernetes distribution and add deployment via kubectl
