### PR TITLE
fix: add root CA bundle to docker image (#591)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,13 @@ COPY version/ version/
 # Build
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
+FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:8.4 as ubi-minimal
+
 FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-micro:8.4
+
+# copy Root CA bundle from ubi-minimal
+COPY --from=ubi-minimal /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 

--- a/deploy/examples/dashboards/DashboardFromGrafana.yaml
+++ b/deploy/examples/dashboards/DashboardFromGrafana.yaml
@@ -6,5 +6,6 @@ metadata:
     app: grafana
 spec:
   grafanaCom:
-    id: 10441
-    revision: 1
+    id: 1860
+    revision: 23
+  json: ""

--- a/hack/clean_e2e.sh
+++ b/hack/clean_e2e.sh
@@ -7,6 +7,7 @@ DEBUG_FILE="/tmp/grafana_e2e_debug.txt"
 kubectl delete -f deploy/examples/Grafana.yaml -n $NAMESPACE
 
 kubectl delete -f deploy/examples/dashboards/SimpleDashboard.yaml -n $NAMESPACE
+kubectl delete -f deploy/examples/dashboards/DashboardFromGrafana.yaml -n $NAMESPACE
 kubectl delete -f deploy/examples/datasources/Prometheus.yaml -n $NAMESPACE
 
 sleep 2

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -103,7 +103,10 @@ if [[ $NUM_DASHBOARDS != 2 ]]; then
   exit 1
 fi
 
-GRAFANA_DASHBOARDS=$(curl $HEADER "http://admin:$PASSWORD@localhost:3000/api/dashboards/uid/$GRAFANA_TOP_FOLDER_ID")
+# get dashboard UID
+GRAFANA_TOP_DASHBOARD_UID=$(echo $DASHBOARDOUTPUT |jq -r '.[0].uid')
+
+GRAFANA_DASHBOARD=$(curl $HEADER "http://admin:$PASSWORD@localhost:3000/api/dashboards/uid/$GRAFANA_TOP_DASHBOARD_UID")
 sleep 1
 FOLDER_ID=$(echo $GRAFANA_DASHBOARD |jq -r .meta.folderId)
 if [[ $FOLDER_ID != 0 ]]; then


### PR DESCRIPTION
## Description
Adds the root CA bundle to the final docker image so enable downloading dashboards from public HTTPS URLs

## Relevant issues/tickets
#591 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

I haven't properly tested in a cluster, however I've verified the ca-bundle.crt file in my workaround described in #591 is in the same location, permissions and contents compared to running the new docker image locally.

You can verify this by creating a dashboard like so:

```yaml
apiVersion: integreatly.org/v1alpha1
kind: GrafanaDashboard
metadata:
  name: node-exporter-full
  labels:
    app: grafana
spec:
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "Prometheus"
  grafanaCom:
    id: 1860
    revision: 23
  json: ""
```

I need to jump on work things so don't have time to verify in a cluster myself. I may have time at the weekend, failing that I can make time next week, but if someone else wants to verify feel free.
