### PR TITLE
fix: add omitempty to dashboard spec json field and generate docs

### DIFF
--- a/api/integreatly/v1alpha1/grafanadashboard_types.go
+++ b/api/integreatly/v1alpha1/grafanadashboard_types.go
@@ -32,9 +32,7 @@ import (
 
 // GrafanaDashboardSpec defines the desired state of GrafanaDashboard
 type GrafanaDashboardSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-	Json             string                            `json:"json"`
+	Json             string                            `json:"json,omitempty"`
 	Jsonnet          string                            `json:"jsonnet,omitempty"`
 	Plugins          PluginList                        `json:"plugins,omitempty"`
 	Url              string                            `json:"url,omitempty"`

--- a/api/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/api/integreatly/v1alpha1/grafanadatasource_types.go
@@ -28,9 +28,6 @@ import (
 
 // GrafanaDataSourceSpec defines the desired state of GrafanaDataSource
 type GrafanaDataSourceSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	Datasources []GrafanaDataSourceFields `json:"datasources"`
 	Name        string                    `json:"name"`
 }

--- a/api/integreatly/v1alpha1/grafananotificationchannel_types.go
+++ b/api/integreatly/v1alpha1/grafananotificationchannel_types.go
@@ -11,8 +11,6 @@ const GrafanaNotificationChannelKind = "GrafanaNotificationChannel"
 
 // GrafanaNotificationChannelSpec defines the desired state of GrafanaNotificationChannel
 type GrafanaNotificationChannelSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	Json string `json:"json"`
 	Name string `json:"name"`
 }

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 
+# Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
@@ -8,8 +9,12 @@ LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.13.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/grafana-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/grafana-operator-controller-manager-metrics-service_v1_service.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager

--- a/bundle/manifests/grafana-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/grafana-operator.clusterserviceversion.yaml
@@ -12,7 +12,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: GrafanaDashboard
+    - description: GrafanaDashboard is the Schema for the grafanadashboards API
+      displayName: Grafana Dashboard
+      kind: GrafanaDashboard
       name: grafanadashboards.integreatly.org
       version: v1alpha1
     - kind: GrafanaDataSource
@@ -21,7 +23,9 @@ spec:
     - kind: GrafanaNotificationChannel
       name: grafananotificationchannels.integreatly.org
       version: v1alpha1
-    - kind: Grafana
+    - description: Grafana is the Schema for the grafanas API
+      displayName: Grafana
+      kind: Grafana
       name: grafanas.integreatly.org
       version: v1alpha1
   description: |
@@ -210,7 +214,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: default
+        serviceAccountName: grafana-operator-controller-manager
       deployments:
       - name: grafana-operator-controller-manager
         spec:
@@ -235,6 +239,7 @@ spec:
                 ports:
                 - containerPort: 8443
                   name: https
+                  protocol: TCP
                 resources: {}
               - args:
                 - --health-probe-bind-address=:8081
@@ -269,21 +274,32 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 100m
+                    cpu: 200m
                     memory: 300Mi
                   requests:
                     cpu: 100m
                     memory: 100Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              serviceAccountName: grafana-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
         - apiGroups:
           - ""
-          - coordination.k8s.io
           resources:
           - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
           - leases
           verbs:
           - get
@@ -300,7 +316,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: default
+        serviceAccountName: grafana-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: true

--- a/bundle/manifests/integreatly.org_grafanadashboards.yaml
+++ b/bundle/manifests/integreatly.org_grafanadashboards.yaml
@@ -20,10 +20,14 @@ spec:
         description: GrafanaDashboard is the Schema for the grafanadashboards API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -37,10 +41,12 @@ spec:
                     description: The key to select.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                   optional:
-                    description: Specify whether the ConfigMap or its key must be defined
+                    description: Specify whether the ConfigMap or its key must be
+                      defined
                     type: boolean
                 required:
                 - key
@@ -69,7 +75,6 @@ spec:
                 - id
                 type: object
               json:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
                 type: string
               jsonnet:
                 type: string
@@ -88,8 +93,6 @@ spec:
                 type: array
               url:
                 type: string
-            required:
-            - json
             type: object
           status:
             type: object

--- a/bundle/manifests/integreatly.org_grafanadatasources.yaml
+++ b/bundle/manifests/integreatly.org_grafanadatasources.yaml
@@ -20,10 +20,14 @@ spec:
         description: GrafanaDataSource is the Schema for the grafanadatasources API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -48,10 +52,13 @@ spec:
                     isDefault:
                       type: boolean
                     jsonData:
-                      description: The most common json options See https://grafana.com/docs/administration/provisioning/#datasources
+                      description: GrafanaDataSourceJsonData contains the most common
+                        json options See https://grafana.com/docs/administration/provisioning/#datasources
                       properties:
                         addCorsHeader:
-                          description: ' Useful fields for clickhouse datasource  See https://github.com/Vertamedia/clickhouse-grafana/tree/master/dist/README.md#configure-the-datasource-with-provisioning  See https://github.com/Vertamedia/clickhouse-grafana/tree/master/src/datasource.ts#L44'
+                          description: ' Useful fields for clickhouse datasource  See
+                            https://github.com/Vertamedia/clickhouse-grafana/tree/master/dist/README.md#configure-the-datasource-with-provisioning  See
+                            https://github.com/Vertamedia/clickhouse-grafana/tree/master/src/datasource.ts#L44'
                           type: boolean
                         appInsightsAppId:
                           description: Fields for Azure data sources
@@ -104,6 +111,9 @@ spec:
                           type: string
                         esVersion:
                           type: integer
+                        githubUrl:
+                          description: Fields for Github data sources
+                          type: string
                         graphiteVersion:
                           type: string
                         httpHeaderName1:
@@ -129,6 +139,9 @@ spec:
                           type: string
                         httpMode:
                           description: Fields for InfluxDB data sources
+                          type: string
+                        implementation:
+                          description: Fields for Alertmanager data sources
                           type: string
                         interval:
                           type: string
@@ -214,9 +227,13 @@ spec:
                     password:
                       type: string
                     secureJsonData:
-                      description: The most common secure json options See https://grafana.com/docs/administration/provisioning/#datasources
+                      description: GrafanaDataSourceSecureJsonData contains the most
+                        common secure json options See https://grafana.com/docs/administration/provisioning/#datasources
                       properties:
                         accessKey:
+                          type: string
+                        accessToken:
+                          description: Fields for Github data sources
                           type: string
                         appInsightsApiKey:
                           type: string

--- a/bundle/manifests/integreatly.org_grafananotificationchannels.yaml
+++ b/bundle/manifests/integreatly.org_grafananotificationchannels.yaml
@@ -17,21 +17,26 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GrafanaNotificationChannel is the Schema for the GrafanaNotificationChannels API
+        description: GrafanaNotificationChannel is the Schema for the GrafanaNotificationChannels
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: GrafanaNotificationChannelSpec defines the desired state of GrafanaNotificationChannel
+            description: GrafanaNotificationChannelSpec defines the desired state
+              of GrafanaNotificationChannel
             properties:
               json:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file'
                 type: string
               name:
                 type: string
@@ -40,7 +45,8 @@ spec:
             - name
             type: object
           status:
-            description: GrafanaNotificationChannelStatus defines the observed state of GrafanaNotificationChannel
+            description: GrafanaNotificationChannelStatus defines the observed state
+              of GrafanaNotificationChannel
             properties:
               hash:
                 type: string

--- a/bundle/manifests/integreatly.org_grafanas.yaml
+++ b/bundle/manifests/integreatly.org_grafanas.yaml
@@ -20,10 +20,14 @@ spec:
         description: Grafana is the Schema for the grafanas API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -32,7 +36,7 @@ spec:
               baseImage:
                 type: string
               client:
-                description: Grafana API client settings
+                description: GrafanaClient contains the Grafana API client settings
                 properties:
                   preferService:
                     nullable: true
@@ -373,6 +377,8 @@ spec:
                     type: object
                   dashboards:
                     properties:
+                      default_home_dashboard_path:
+                        type: string
                       versions_to_keep:
                         nullable: true
                         type: integer
@@ -729,31 +735,57 @@ spec:
                 type: array
               containers:
                 items:
-                  description: A single application container that you want to run within a pod.
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      description: 'Arguments to the entrypoint. The docker image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                        double $$, ie: $$(VAR_NAME). Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     command:
-                      description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. The $(VAR_NAME) syntax
+                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                        references will never be expanded, regardless of whether the
+                        variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     env:
-                      description: List of environment variables to set in the container. Cannot be updated.
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present in a Container.
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
                                 description: Selects a key of a ConfigMap.
@@ -762,37 +794,53 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the specified API version.
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes, optional for env vars'
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
@@ -802,16 +850,22 @@ spec:
                                 - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's namespace
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key must be defined
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -822,28 +876,41 @@ spec:
                         type: object
                       type: array
                     envFrom:
-                      description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be defined
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
                                 description: Specify whether the Secret must be defined
@@ -852,22 +919,41 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
                       type: string
                     imagePullPolicy:
-                      description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                       type: string
                     lifecycle:
-                      description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
                       properties:
                         postStart:
-                          description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
@@ -876,12 +962,16 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -901,38 +991,66 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
-                          description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The reason for termination is passed
+                            to the handler. The Pod''s termination grace period countdown
+                            begins before the PreStop hooked is executed. Regardless
+                            of the outcome of the handler, the container will eventually
+                            terminate within the Pod''s termination grace period.
+                            Other management of the container blocks until the hook
+                            completes or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
@@ -941,12 +1059,16 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -966,25 +1088,33 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -992,31 +1122,47 @@ spec:
                           type: object
                       type: object
                     livenessProbe:
-                      description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -1036,71 +1182,104 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     name:
-                      description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a single container.
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
-                            description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
                             description: What host IP to bind the external port to.
                             type: string
                           hostPort:
-                            description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
                           name:
-                            description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
                             type: string
                           protocol:
                             default: TCP
-                            description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -1111,31 +1290,47 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
-                      description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -1155,48 +1350,65 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     resources:
-                      description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       properties:
                         limits:
                           additionalProperties:
@@ -1205,7 +1417,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -1214,119 +1427,210 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     securityContext:
-                      description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      description: 'Security options the pod should run with. More
+                        info: https://kubernetes.io/docs/concepts/policy/security-context/
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                       properties:
                         allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
                           type: boolean
                         capabilities:
-                          description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
                           properties:
                             add:
                               description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                             drop:
                               description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
-                          description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
                           type: boolean
                         procMount:
-                          description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
                           type: string
                         readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem. Default is false.
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
                           type: boolean
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies to the container.
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies to the container.
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies to the container.
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies to the container.
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
-                          description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     startupProbe:
-                      description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -1346,71 +1650,117 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     stdin:
-                      description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
                       type: boolean
                     stdinOnce:
-                      description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
                       type: boolean
                     terminationMessagePath:
-                      description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                       type: string
                     terminationMessagePolicy:
-                      description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
                       type: string
                     tty:
-                      description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be used by the container.
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block device within a container.
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container that the device will be mapped to.
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim in the pod
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -1418,27 +1768,40 @@ spec:
                         type: object
                       type: array
                     volumeMounts:
-                      description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume within a container.
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
-                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
-                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
                             type: string
                           name:
                             description: This must match the Name of a Volume.
                             type: string
                           readOnly:
-                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
-                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
-                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -1446,7 +1809,9 @@ spec:
                         type: object
                       type: array
                     workingDir:
-                      description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
                       type: string
                   required:
                   - name
@@ -1454,21 +1819,34 @@ spec:
                 type: array
               dashboardLabelSelector:
                 items:
-                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -1480,26 +1858,43 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                 type: array
               dashboardNamespaceSelector:
-                description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                description: A label selector is a label query over a set of resources.
+                  The result of matchLabels and matchExpressions are ANDed. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -1511,11 +1906,16 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
                     type: object
                 type: object
               dataStorage:
-                description: GrafanaDataStorage provides a means to configure the grafana data storage
+                description: GrafanaDataStorage provides a means to configure the
+                  grafana data storage
                 properties:
                   accessModes:
                     items:
@@ -1545,29 +1945,61 @@ spec:
                     description: Affinity is a group of affinity scheduling rules.
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for the pod.
+                        description: Describes node affinity scheduling rules for
+                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
                             items:
-                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with the corresponding weight.
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1577,18 +2009,35 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1599,7 +2048,8 @@ spec:
                                       type: array
                                   type: object
                                 weight:
-                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -1608,26 +2058,53 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms. The terms are ORed.
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
                                 items:
-                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1637,18 +2114,35 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1664,32 +2158,65 @@ spec:
                             type: object
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
+                                      description: A label query over a set of resources,
+                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1701,22 +2228,37 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -1725,26 +2267,56 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1756,16 +2328,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -1773,32 +2358,65 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
+                                      description: A label query over a set of resources,
+                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1810,22 +2428,37 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -1834,26 +2467,56 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1865,16 +2528,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -1887,101 +2563,175 @@ spec:
                       type: string
                     type: object
                   containerSecurityContext:
-                    description: SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
                     properties:
                       allowPrivilegeEscalation:
-                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
                         type: boolean
                       capabilities:
-                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
                         properties:
                           add:
                             description: Added capabilities
                             items:
-                              description: Capability represent POSIX capabilities type
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                           drop:
                             description: Removed capabilities
                             items:
-                              description: Capability represent POSIX capabilities type
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                         type: object
                       privileged:
-                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
                         type: boolean
                       procMount:
-                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
                         type: string
                       readOnlyRootFilesystem:
-                        description: Whether this container has a read-only root filesystem. Default is false.
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
                         type: boolean
                       runAsGroup:
-                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
                         format: int64
                         type: integer
                       runAsNonRoot:
-                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
                         type: boolean
                       runAsUser:
-                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
                         format: int64
                         type: integer
                       seLinuxOptions:
-                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
                         properties:
                           level:
-                            description: Level is SELinux level label that applies to the container.
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
                           role:
-                            description: Role is a SELinux role label that applies to the container.
+                            description: Role is a SELinux role label that applies
+                              to the container.
                             type: string
                           type:
-                            description: Type is a SELinux type label that applies to the container.
+                            description: Type is a SELinux type label that applies
+                              to the container.
                             type: string
                           user:
-                            description: User is a SELinux user label that applies to the container.
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
                       seccompProfile:
-                        description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
                         properties:
                           localhostProfile:
-                            description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
                             type: string
                           type:
-                            description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
                             type: string
                         required:
                         - type
                         type: object
                       windowsOptions:
-                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
                         properties:
                           gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
                           gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
                           runAsUserName:
-                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
                             type: string
                         type: object
                     type: object
                   env:
                     items:
-                      description: EnvVar represents an environment variable present in a Container.
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
                               description: Selects a key of a ConfigMap.
@@ -1990,37 +2740,51 @@ spec:
                                   description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its key must be defined
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                             fieldRef:
-                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the specified API version.
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                             resourceFieldRef:
-                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes, optional for env vars'
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
@@ -2030,16 +2794,21 @@ spec:
                               - resource
                               type: object
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's namespace
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key must be defined
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2051,26 +2820,30 @@ spec:
                     type: array
                   envFrom:
                     items:
-                      description: EnvFromSource represents the source of a set of ConfigMaps
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
                       properties:
                         configMapRef:
                           description: The ConfigMap to select from
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
                               description: Specify whether the ConfigMap must be defined
                               type: boolean
                           type: object
                         prefix:
-                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
                           type: string
                         secretRef:
                           description: The Secret to select from
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
                               description: Specify whether the Secret must be defined
@@ -2080,25 +2853,37 @@ spec:
                     type: array
                   extraVolumeMounts:
                     items:
-                      description: VolumeMount describes a mounting of a Volume within a container.
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
                       properties:
                         mountPath:
-                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
                           type: string
                         mountPropagation:
-                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
                           type: string
                         name:
                           description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
                           type: boolean
                         subPath:
-                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive.
                           type: string
                       required:
                       - mountPath
@@ -2107,32 +2892,51 @@ spec:
                     type: array
                   extraVolumes:
                     items:
-                      description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
-                          description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          description: 'AWSElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                              description: 'The partition in the volume that you want
+                                to mount. If omitted, the default is to mount by volume
+                                name. Examples: For volume /dev/sda1, you specify
+                                the partition as "1". Similarly, the volume partition
+                                for /dev/sda is "0" (or you can leave the property
+                                empty).'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'Specify "true" to force and set the ReadOnly
+                                property in VolumeMounts to "true". If omitted, the
+                                default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: boolean
                             volumeID:
-                              description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'Unique ID of the persistent disk resource
+                                in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: string
                           required:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          description: AzureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
                           properties:
                             cachingMode:
-                              description: 'Host Caching mode: None, Read Only, Read Write.'
+                              description: 'Host Caching mode: None, Read Only, Read
+                                Write.'
                               type: string
                             diskName:
                               description: The Name of the data disk in the blob storage
@@ -2141,26 +2945,37 @@ spec:
                               description: The URI the data disk in the blob storage
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
                               type: string
                             kind:
-                              description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                              description: 'Expected values Shared: multiple blob
+                                disks per storage account  Dedicated: single blob
+                                disk per storage account  Managed: azure managed data
+                                disk (only in managed availability set). defaults
+                                to shared'
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                           required:
                           - diskName
                           - diskURI
                           type: object
                         azureFile:
-                          description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          description: AzureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
-                              description: the name of secret that contains Azure Storage Account Name and Key
+                              description: the name of secret that contains Azure
+                                Storage Account Name and Key
                               type: string
                             shareName:
                               description: Share Name
@@ -2170,78 +2985,131 @@ spec:
                           - shareName
                           type: object
                         cephfs:
-                          description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                          description: CephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
                           properties:
                             monitors:
-                              description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'Required: Monitors is a collection of
+                                Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             path:
-                              description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                              description: 'Optional: Used as the mounted root, rather
+                                than the full Ceph tree, default is /'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: boolean
                             secretFile:
-                              description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'Optional: SecretFile is the path to key
+                                ring for User, default is /etc/ceph/user.secret More
+                                info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'Optional: SecretRef is reference to the
+                                authentication secret for User, default is empty.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             user:
-                              description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'Optional: User is the rados user name,
+                                default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                           required:
                           - monitors
                           type: object
                         cinder:
-                          description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          description: 'Cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: boolean
                             secretRef:
-                              description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                              description: 'Optional: points to a secret object containing
+                                parameters used to connect to OpenStack.'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             volumeID:
-                              description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'volume id used to identify the volume
+                                in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                           required:
                           - volumeID
                           type: object
                         configMap:
-                          description: ConfigMap represents a configMap that should populate this volume
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced ConfigMap will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the ConfigMap, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
                               items:
-                                description: Maps a string key to a path within a volume.
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
                                     description: The key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -2249,81 +3117,136 @@ spec:
                                 type: object
                               type: array
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its keys must be defined
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
                               type: boolean
                           type: object
                         csi:
-                          description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                          description: CSI (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
                           properties:
                             driver:
-                              description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                              description: Driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                              description: Filesystem type to mount. Ex. "ext4", "xfs",
+                                "ntfs". If not provided, the empty value is passed
+                                to the associated CSI driver which will determine
+                                the default filesystem to apply.
                               type: string
                             nodePublishSecretRef:
-                              description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                              description: NodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             readOnly:
-                              description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                              description: Specifies a read-only configuration for
+                                the volume. Defaults to false (read/write).
                               type: boolean
                             volumeAttributes:
                               additionalProperties:
                                 type: string
-                              description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                              description: VolumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
                               type: object
                           required:
                           - driver
                           type: object
                         downwardAPI:
-                          description: DownwardAPI represents downward API about the pod that should populate this volume
+                          description: DownwardAPI represents downward API about the
+                            pod that should populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: Items is a list of downward API volume file
+                              description: Items is a list of downward API volume
+                                file
                               items:
-                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
                                 properties:
                                   fieldRef:
-                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in the specified API version.
+                                        description: Path of the field to select in
+                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                   mode:
-                                    description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
                                     type: string
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for volumes, optional for env vars'
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
@@ -2338,57 +3261,133 @@ spec:
                               type: array
                           type: object
                         emptyDir:
-                          description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          description: 'EmptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           properties:
                             medium:
-                              description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'What type of storage medium should back
+                                this directory. The default is "" which means to use
+                                the node''s default medium. Must be an empty string
+                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              description: 'Total amount of local storage required
+                                for this EmptyDir volume. The size limit is also applicable
+                                for memory medium. The maximum usage on memory medium
+                                EmptyDir would be the minimum value between the SizeLimit
+                                specified here and the sum of memory limits of all
+                                containers in a pod. The default is nil which means
+                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
                         ephemeral:
-                          description: "Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                          description: "Ephemeral represents a volume that is handled
+                            by a cluster storage driver (Alpha feature). The volume's
+                            lifecycle is tied to the pod that defines it - it will
+                            be created before the pod starts, and deleted when the
+                            pod is removed. \n Use this if: a) the volume is only
+                            needed while the pod runs, b) features of normal volumes
+                            like restoring from snapshot or capacity    tracking are
+                            needed, c) the storage driver is specified through a storage
+                            class, and d) the storage driver supports dynamic volume
+                            provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                            for more    information on the connection between this
+                            volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                            or one of the vendor-specific APIs for volumes that persist
+                            for longer than the lifecycle of an individual pod. \n
+                            Use CSI for light-weight local ephemeral volumes if the
+                            CSI driver is meant to be used that way - see the documentation
+                            of the driver for more information. \n A pod can use both
+                            types of ephemeral volumes and persistent volumes at the
+                            same time."
                           properties:
                             readOnly:
-                              description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                              description: Specifies a read-only configuration for
+                                the volume. Defaults to false (read/write).
                               type: boolean
                             volumeClaimTemplate:
-                              description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                              description: "Will be used to create a stand-alone PVC
+                                to provision the volume. The pod in which this EphemeralVolumeSource
+                                is embedded will be the owner of the PVC, i.e. the
+                                PVC will be deleted together with the pod.  The name
+                                of the PVC will be `<pod name>-<volume name>` where
+                                `<volume name>` is the name from the `PodSpec.Volumes`
+                                array entry. Pod validation will reject the pod if
+                                the concatenated name is not valid for a PVC (for
+                                example, too long). \n An existing PVC with that name
+                                that is not owned by the pod will *not* be used for
+                                the pod to avoid using an unrelated volume by mistake.
+                                Starting the pod is then blocked until the unrelated
+                                PVC is removed. If such a pre-created PVC is meant
+                                to be used by the pod, the PVC has to updated with
+                                an owner reference to the pod once the pod exists.
+                                Normally this should not be necessary, but it may
+                                be useful when manually reconstructing a broken cluster.
+                                \n This field is read-only and no changes will be
+                                made by Kubernetes to the PVC after it has been created.
+                                \n Required, must not be nil."
                               properties:
                                 metadata:
-                                  description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
                                   type: object
                                 spec:
-                                  description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
                                   properties:
                                     accessModes:
-                                      description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: 'AccessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) * An existing custom resource that implements data population (Alpha) In order to use custom resource types that implement data population, the AnyVolumeDataSource feature gate must be enabled. If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.'
+                                      description: 'This field can be used to specify
+                                        either: * An existing VolumeSnapshot object
+                                        (snapshot.storage.k8s.io/VolumeSnapshot) *
+                                        An existing PVC (PersistentVolumeClaim) *
+                                        An existing custom resource that implements
+                                        data population (Alpha) In order to use custom
+                                        resource types that implement data population,
+                                        the AnyVolumeDataSource feature gate must
+                                        be enabled. If the provisioner or an external
+                                        controller can support the specified data
+                                        source, it will create a new volume based
+                                        on the contents of the specified data source.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
+                                          description: Kind is the type of resource
+                                            being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
+                                          description: Name is the name of resource
+                                            being referenced
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
-                                      description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      description: 'Resources represents the minimum
+                                        resources the volume should have. More info:
+                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -2397,7 +3396,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -2406,25 +3407,47 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                           type: object
                                       type: object
                                     selector:
-                                      description: A label query over volumes to consider for binding.
+                                      description: A label query over volumes to consider
+                                        for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2436,17 +3459,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     storageClassName:
-                                      description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      description: 'Name of the StorageClass required
+                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
                                       type: string
                                     volumeName:
-                                      description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                      description: VolumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                               required:
@@ -2454,17 +3487,24 @@ spec:
                               type: object
                           type: object
                         fc:
-                          description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                          description: FC represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                              description: 'Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified. TODO: how do we prevent errors in the
+                                filesystem from compromising the machine'
                               type: string
                             lun:
                               description: 'Optional: FC target lun number'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                               type: boolean
                             targetWWNs:
                               description: 'Optional: FC target worldwide names (WWNs)'
@@ -2472,19 +3512,26 @@ spec:
                                 type: string
                               type: array
                             wwids:
-                              description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                              description: 'Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
                               items:
                                 type: string
                               type: array
                           type: object
                         flexVolume:
-                          description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                          description: FlexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
                           properties:
                             driver:
-                              description: Driver is the name of the driver to use for this volume.
+                              description: Driver is the name of the driver to use
+                                for this volume.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". The default filesystem depends on FlexVolume
+                                script.
                               type: string
                             options:
                               additionalProperties:
@@ -2492,52 +3539,89 @@ spec:
                               description: 'Optional: Extra command options if any.'
                               type: object
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                               type: boolean
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                              description: 'Optional: SecretRef is reference to the
+                                secret object containing sensitive information to
+                                pass to the plugin scripts. This may be empty if no
+                                secret object is specified. If the secret object contains
+                                more than one secret, all secrets are passed to the
+                                plugin scripts.'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                           required:
                           - driver
                           type: object
                         flocker:
-                          description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                          description: Flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
                           properties:
                             datasetName:
-                              description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                              description: Name of the dataset stored as metadata
+                                -> name on the dataset for Flocker should be considered
+                                as deprecated
                               type: string
                             datasetUUID:
-                              description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                              description: UUID of the dataset. This is unique identifier
+                                of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
-                          description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          description: 'GCEPersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'The partition in the volume that you want
+                                to mount. If omitted, the default is to mount by volume
+                                name. Examples: For volume /dev/sda1, you specify
+                                the partition as "1". Similarly, the volume partition
+                                for /dev/sda is "0" (or you can leave the property
+                                empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               format: int32
                               type: integer
                             pdName:
-                              description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'Unique name of the PD resource in GCE.
+                                Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: boolean
                           required:
                           - pdName
                           type: object
                         gitRepo:
-                          description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                          description: 'GitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
                           properties:
                             directory:
-                              description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                              description: Target directory name. Must not contain
+                                or start with '..'.  If '.' is supplied, the volume
+                                directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
                               type: string
                             repository:
                               description: Repository URL
@@ -2549,35 +3633,53 @@ spec:
                           - repository
                           type: object
                         glusterfs:
-                          description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          description: 'Glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                           properties:
                             endpoints:
-                              description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              description: 'EndpointsName is the endpoint name that
+                                details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             path:
-                              description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              description: 'Path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              description: 'ReadOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: boolean
                           required:
                           - endpoints
                           - path
                           type: object
                         hostPath:
-                          description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                          description: 'HostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                            --- TODO(jonesdl) We need to restrict who can use host
+                            directory mounts and who can/can not mount host directories
+                            as read/write.'
                           properties:
                             path:
-                              description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              description: 'Path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                             type:
-                              description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              description: 'Type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                           required:
                           - path
                           type: object
                         iscsi:
-                          description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          description: 'ISCSI represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                           properties:
                             chapAuthDiscovery:
                               description: whether support iSCSI Discovery CHAP authentication
@@ -2586,38 +3688,56 @@ spec:
                               description: whether support iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
-                              description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
                               type: string
                             initiatorName:
-                              description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                              description: Custom iSCSI Initiator Name. If initiatorName
+                                is specified with iscsiInterface simultaneously, new
+                                iSCSI interface <target portal>:<volume name> will
+                                be created for the connection.
                               type: string
                             iqn:
                               description: Target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
-                              description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                              description: iSCSI Interface Name that uses an iSCSI
+                                transport. Defaults to 'default' (tcp).
                               type: string
                             lun:
                               description: iSCSI Target Lun number.
                               format: int32
                               type: integer
                             portals:
-                              description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                              description: iSCSI Target Portal List. The portal is
+                                either an IP or ip_addr:port if the port is other
+                                than default (typically TCP ports 860 and 3260).
                               items:
                                 type: string
                               type: array
                             readOnly:
-                              description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                              description: ReadOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
                               type: boolean
                             secretRef:
-                              description: CHAP Secret for iSCSI target and initiator authentication
+                              description: CHAP Secret for iSCSI target and initiator
+                                authentication
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             targetPortal:
-                              description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                              description: iSCSI Target Portal. The Portal is either
+                                an IP or ip_addr:port if the port is other than default
+                                (typically TCP ports 860 and 3260).
                               type: string
                           required:
                           - iqn
@@ -2625,92 +3745,153 @@ spec:
                           - targetPortal
                           type: object
                         name:
-                          description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         nfs:
-                          description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          description: 'NFS represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           properties:
                             path:
-                              description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'Path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'ReadOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: boolean
                             server:
-                              description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'Server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                           required:
                           - path
                           - server
                           type: object
                         persistentVolumeClaim:
-                          description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          description: 'PersistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             claimName:
-                              description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'ClaimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               type: string
                             readOnly:
-                              description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                              description: Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
                               type: boolean
                           required:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                          description: PhotonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
                               type: string
                             pdID:
-                              description: ID that identifies Photon Controller persistent disk
+                              description: ID that identifies Photon Controller persistent
+                                disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                          description: PortworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                              description: FSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
-                              description: VolumeID uniquely identifies a Portworx volume
+                              description: VolumeID uniquely identifies a Portworx
+                                volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
-                          description: Items for all in one resources secrets, configmaps, and downward API
+                          description: Items for all in one resources secrets, configmaps,
+                            and downward API
                           properties:
                             defaultMode:
-                              description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                              description: Mode bits used to set permissions on created
+                                files by default. Must be an octal value between 0000
+                                and 0777 or a decimal value between 0 and 511. YAML
+                                accepts both octal and decimal values, JSON requires
+                                decimal values for mode bits. Directories within the
+                                path are not affected by this setting. This might
+                                be in conflict with other options that affect the
+                                file mode, like fsGroup, and the result can be other
+                                mode bits set.
                               format: int32
                               type: integer
                             sources:
                               description: list of volume projections
                               items:
-                                description: Projection that may be projected along with other supported volume types
+                                description: Projection that may be projected along
+                                  with other supported volume types
                                 properties:
                                   configMap:
-                                    description: information about the configMap data to project
+                                    description: information about the configMap data
+                                      to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
                                               description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file. Must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -2718,54 +3899,92 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
+                                        description: Specify whether the ConfigMap
+                                          or its keys must be defined
                                         type: boolean
                                     type: object
                                   downwardAPI:
-                                    description: information about the downwardAPI data to project
+                                    description: information about the downwardAPI
+                                      data to project
                                     properties:
                                       items:
-                                        description: Items is a list of DownwardAPIVolume file
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
@@ -2776,22 +3995,50 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: information about the secret data to project
+                                    description: information about the secret data
+                                      to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
                                               description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file. Must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -2799,24 +4046,45 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or its key must be defined
+                                        description: Specify whether the Secret or
+                                          its key must be defined
                                         type: boolean
                                     type: object
                                   serviceAccountToken:
-                                    description: information about the serviceAccountToken data to project
+                                    description: information about the serviceAccountToken
+                                      data to project
                                     properties:
                                       audience:
-                                        description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                        description: Audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
                                         type: string
                                       expirationSeconds:
-                                        description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                        description: ExpirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
                                         format: int64
                                         type: integer
                                       path:
-                                        description: Path is the path relative to the mount point of the file to project the token into.
+                                        description: Path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
                                         type: string
                                     required:
                                     - path
@@ -2825,103 +4093,148 @@ spec:
                               type: array
                           type: object
                         quobyte:
-                          description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                          description: Quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
                           properties:
                             group:
-                              description: Group to map volume access to Default is no group
+                              description: Group to map volume access to Default is
+                                no group
                               type: string
                             readOnly:
-                              description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                              description: ReadOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
                               type: boolean
                             registry:
-                              description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                              description: Registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
                               type: string
                             tenant:
-                              description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                              description: Tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
                               type: string
                             user:
-                              description: User to map volume access to Defaults to serivceaccount user
+                              description: User to map volume access to Defaults to
+                                serivceaccount user
                               type: string
                             volume:
-                              description: Volume is a string that references an already created Quobyte volume by name.
+                              description: Volume is a string that references an already
+                                created Quobyte volume by name.
                               type: string
                           required:
                           - registry
                           - volume
                           type: object
                         rbd:
-                          description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                          description: 'RBD represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                TODO: how do we prevent errors in the filesystem from
+                                compromising the machine'
                               type: string
                             image:
                               description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             keyring:
-                              description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'Keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             monitors:
-                              description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'A collection of Ceph monitors. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             pool:
-                              description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'The rados pool name. Default is rbd. More
+                                info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: boolean
                             secretRef:
-                              description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'SecretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             user:
-                              description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'The rados user name. Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                           required:
                           - image
                           - monitors
                           type: object
                         scaleIO:
-                          description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          description: ScaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Default is "xfs".
                               type: string
                             gateway:
                               description: The host address of the ScaleIO API Gateway.
                               type: string
                             protectionDomain:
-                              description: The name of the ScaleIO Protection Domain for the configured storage.
+                              description: The name of the ScaleIO Protection Domain
+                                for the configured storage.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                              description: SecretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             sslEnabled:
-                              description: Flag to enable/disable SSL communication with Gateway, default false
+                              description: Flag to enable/disable SSL communication
+                                with Gateway, default false
                               type: boolean
                             storageMode:
-                              description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                              description: Indicates whether the storage for a volume
+                                should be ThickProvisioned or ThinProvisioned. Default
+                                is ThinProvisioned.
                               type: string
                             storagePool:
-                              description: The ScaleIO Storage Pool associated with the protection domain.
+                              description: The ScaleIO Storage Pool associated with
+                                the protection domain.
                               type: string
                             system:
-                              description: The name of the storage system as configured in ScaleIO.
+                              description: The name of the storage system as configured
+                                in ScaleIO.
                               type: string
                             volumeName:
-                              description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                              description: The name of a volume already created in
+                                the ScaleIO system that is associated with this volume
+                                source.
                               type: string
                           required:
                           - gateway
@@ -2929,26 +4242,57 @@ spec:
                           - system
                           type: object
                         secret:
-                          description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          description: 'Secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start
+                                with '..'.
                               items:
-                                description: Maps a string key to a path within a volume.
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
                                     description: The key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -2956,46 +4300,73 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: Specify whether the Secret or its keys must be defined
+                              description: Specify whether the Secret or its keys
+                                must be defined
                               type: boolean
                             secretName:
-                              description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
                         storageos:
-                          description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          description: StorageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                              description: SecretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             volumeName:
-                              description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                              description: VolumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
                               type: string
                             volumeNamespace:
-                              description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                              description: VolumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
                               type: string
                           type: object
                         vsphereVolume:
-                          description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                          description: VsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
                               type: string
                             storagePolicyID:
-                              description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                              description: Storage Policy Based Management (SPBM)
+                                profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
-                              description: Storage Policy Based Management (SPBM) profile name.
+                              description: Storage Policy Based Management (SPBM)
+                                profile name.
                               type: string
                             volumePath:
                               description: Path that identifies vSphere volume vmdk
@@ -3011,7 +4382,9 @@ spec:
                     nullable: true
                     type: boolean
                   httpProxy:
-                    description: GrafanaHttpProxy provides a means to configure the Grafana deployment to use a HTTP(S) proxy when making requests and resolving plugins.
+                    description: GrafanaHttpProxy provides a means to configure the
+                      Grafana deployment to use an HTTP(S) proxy when making requests
+                      and resolving plugins.
                     properties:
                       enabled:
                         type: boolean
@@ -3035,62 +4408,114 @@ spec:
                     nullable: true
                     type: integer
                   securityContext:
-                    description: PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
+                    description: PodSecurityContext holds pod-level security attributes
+                      and common container settings. Some fields are also present
+                      in container.securityContext.  Field values of container.securityContext
+                      take precedence over field values of PodSecurityContext.
                     properties:
                       fsGroup:
-                        description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
                         format: int64
                         type: integer
                       fsGroupChangePolicy:
-                        description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.'
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used.'
                         type: string
                       runAsGroup:
-                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
                         format: int64
                         type: integer
                       runAsNonRoot:
-                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
                         type: boolean
                       runAsUser:
-                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
                         format: int64
                         type: integer
                       seLinuxOptions:
-                        description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
                         properties:
                           level:
-                            description: Level is SELinux level label that applies to the container.
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
                           role:
-                            description: Role is a SELinux role label that applies to the container.
+                            description: Role is a SELinux role label that applies
+                              to the container.
                             type: string
                           type:
-                            description: Type is a SELinux type label that applies to the container.
+                            description: Type is a SELinux type label that applies
+                              to the container.
                             type: string
                           user:
-                            description: User is a SELinux user label that applies to the container.
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
                       seccompProfile:
-                        description: The seccomp options to use by the containers in this pod.
+                        description: The seccomp options to use by the containers
+                          in this pod.
                         properties:
                           localhostProfile:
-                            description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
                             type: string
                           type:
-                            description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
                             type: string
                         required:
                         - type
                         type: object
                       supplementalGroups:
-                        description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
                         items:
                           format: int64
                           type: integer
                         type: array
                       sysctls:
-                        description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
                         items:
                           description: Sysctl defines a kernel parameter to be set
                           properties:
@@ -3106,16 +4531,29 @@ spec:
                           type: object
                         type: array
                       windowsOptions:
-                        description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
                         properties:
                           gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
                           gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
                           runAsUserName:
-                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
                             type: string
                         type: object
                     type: object
@@ -3123,26 +4561,54 @@ spec:
                     nullable: true
                     type: boolean
                   strategy:
-                    description: DeploymentStrategy describes how to replace existing pods with new ones.
+                    description: DeploymentStrategy describes how to replace existing
+                      pods with new ones.
                     properties:
                       rollingUpdate:
-                        description: 'Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.'
+                        description: 'Rolling update config params. Present only if
+                          DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                          this to follow our convention for oneOf, whatever we decide
+                          it to be.'
                         properties:
                           maxSurge:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                            description: 'The maximum number of pods that can be scheduled
+                              above the desired number of pods. Value can be an absolute
+                              number (ex: 5) or a percentage of desired pods (ex:
+                              10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                              number is calculated from percentage by rounding up.
+                              Defaults to 25%. Example: when this is set to 30%, the
+                              new ReplicaSet can be scaled up immediately when the
+                              rolling update starts, such that the total number of
+                              old and new pods do not exceed 130% of desired pods.
+                              Once old pods have been killed, new ReplicaSet can be
+                              scaled up further, ensuring that total number of pods
+                              running at any time during the update is at most 130%
+                              of desired pods.'
                             x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                            description: 'The maximum number of pods that can be unavailable
+                              during the update. Value can be an absolute number (ex:
+                              5) or a percentage of desired pods (ex: 10%). Absolute
+                              number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0. Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet
+                              can be scaled down to 70% of desired pods immediately
+                              when the rolling update starts. Once new pods are ready,
+                              old ReplicaSet can be scaled down further, followed
+                              by scaling up the new ReplicaSet, ensuring that the
+                              total number of pods available at all times during the
+                              update is at least 70% of desired pods.'
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
-                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
                         type: string
                     type: object
                   terminationGracePeriodSeconds:
@@ -3150,29 +4616,48 @@ spec:
                     type: integer
                   tolerations:
                     items:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                 type: object
               ingress:
-                description: GrafanaIngress provides a means to configure the ingress created
+                description: GrafanaIngress provides a means to configure the ingress
+                  created
                 properties:
                   annotations:
                     additionalProperties:
@@ -3195,7 +4680,8 @@ spec:
                   targetPort:
                     type: string
                   termination:
-                    description: 'TLSTerminationType dictates where the secure communication will stop TODO: Reconsider this type in v2'
+                    description: 'TLSTerminationType dictates where the secure communication
+                      will stop TODO: Reconsider this type in v2'
                     type: string
                   tlsEnabled:
                     type: boolean
@@ -3214,7 +4700,8 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
@@ -3223,27 +4710,43 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
               jsonnet:
                 properties:
                   libraryLabelSelector:
-                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -3255,7 +4758,11 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
                         type: object
                     type: object
                 type: object
@@ -3305,7 +4812,8 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
@@ -3314,7 +4822,10 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
               secrets:
@@ -3341,13 +4852,33 @@ spec:
                       description: ServicePort contains information on service's port.
                       properties:
                         appProtocol:
-                          description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                          description: The application protocol for this port. This
+                            field follows standard Kubernetes label syntax. Un-prefixed
+                            names are reserved for IANA standard service names (as
+                            per RFC-6335 and http://www.iana.org/assignments/service-names).
+                            Non-standard protocols should use prefixed names such
+                            as mycompany.com/my-custom-protocol. This is a beta field
+                            that is guarded by the ServiceAppProtocol feature gate
+                            and enabled by default.
                           type: string
                         name:
-                          description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                          description: The name of this port within the service. This
+                            must be a DNS_LABEL. All ports within a ServiceSpec must
+                            have unique names. When considering the endpoints for
+                            a Service, this must match the 'name' field in the EndpointPort.
+                            Optional if only one ServicePort is defined on this service.
                           type: string
                         nodePort:
-                          description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                          description: 'The port on each node on which this service
+                            is exposed when type is NodePort or LoadBalancer.  Usually
+                            assigned by the system. If a value is specified, in-range,
+                            and not in use it will be used, otherwise the operation
+                            will fail.  If not specified, a port will be allocated
+                            if this Service requires one.  If this field is specified
+                            when creating a Service which does not need it, creation
+                            will fail. This field will be wiped when updating a Service
+                            to no longer need it (e.g. changing type from NodePort
+                            to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
                           format: int32
                           type: integer
                         port:
@@ -3356,20 +4887,30 @@ spec:
                           type: integer
                         protocol:
                           default: TCP
-                          description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                          description: The IP protocol for this port. Supports "TCP",
+                            "UDP", and "SCTP". Default is TCP.
                           type: string
                         targetPort:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                          description: 'Number or name of the port to access on the
+                            pods targeted by the service. Number must be in the range
+                            1 to 65535. Name must be an IANA_SVC_NAME. If this is
+                            a string, it will be looked up as a named port in the
+                            target Pod''s container ports. If this is not specified,
+                            the value of the ''port'' field is used (an identity map).
+                            This field is ignored for services with clusterIP=None,
+                            and should be omitted or set equal to the ''port'' field.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                           x-kubernetes-int-or-string: true
                       required:
                       - port
                       type: object
                     type: array
                   type:
-                    description: Service Type string describes ingress methods for a service
+                    description: Service Type string describes ingress methods for
+                      a service
                     type: string
                 type: object
               serviceAccount:
@@ -3380,10 +4921,12 @@ spec:
                     type: object
                   imagePullSecrets:
                     items:
-                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
                     type: array
@@ -3402,7 +4945,8 @@ spec:
             properties:
               dashboards:
                 items:
-                  description: Used to keep a dashboard reference without having access to the dashboard struct itself
+                  description: GrafanaDashboardRef is used to keep a dashboard reference
+                    without having access to the dashboard struct itself
                   properties:
                     folderId:
                       format: int64

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,11 +1,14 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: grafana-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -12,6 +12,9 @@ stages:
     labels:
       suite: basic
       test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
@@ -19,6 +22,9 @@ stages:
     labels:
       suite: olm
       test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
@@ -26,6 +32,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
@@ -33,6 +42,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
@@ -40,6 +52,9 @@ stages:
     labels:
       suite: olm
       test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
@@ -47,3 +62,9 @@ stages:
     labels:
       suite: olm
       test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/crd/bases/integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/integreatly.org_grafanadashboards.yaml
@@ -77,8 +77,6 @@ spec:
                 - id
                 type: object
               json:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file'
                 type: string
               jsonnet:
                 type: string
@@ -97,8 +95,6 @@ spec:
                 type: array
               url:
                 type: string
-            required:
-            - json
             type: object
           status:
             type: object

--- a/config/crd/bases/integreatly.org_grafananotificationchannels.yaml
+++ b/config/crd/bases/integreatly.org_grafananotificationchannels.yaml
@@ -39,9 +39,6 @@ spec:
               of GrafanaNotificationChannel
             properties:
               json:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "operator-sdk generate k8s" to regenerate code after
-                  modifying this file'
                 type: string
               name:
                 type: string

--- a/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
@@ -101,6 +101,16 @@ spec:
       kind: Grafana
       name: grafanas.integreatly.org.integreatly.org
       version: v1alpha1
+    - description: GrafanaDashboard is the Schema for the grafanadashboards API
+      displayName: Grafana Dashboard
+      kind: GrafanaDashboard
+      name: grafanadashboards.integreatly.org
+      version: v1alpha1
+    - description: Grafana is the Schema for the grafanas API
+      displayName: Grafana
+      kind: Grafana
+      name: grafanas.integreatly.org
+      version: v1alpha1
   description: |
     A Kubernetes Operator based on the Operator SDK for creating and managing Grafana instances.
 

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -90,13 +90,6 @@ GrafanaDashboardSpec defines the desired state of GrafanaDashboard
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>json</b></td>
-        <td>string</td>
-        <td>
-          INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b><a href="#grafanadashboardspecconfigmapref">configMapRef</a></b></td>
         <td>object</td>
         <td>
@@ -120,6 +113,13 @@ GrafanaDashboardSpec defines the desired state of GrafanaDashboard
       </tr><tr>
         <td><b><a href="#grafanadashboardspecgrafanacom">grafanaCom</a></b></td>
         <td>object</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>json</b></td>
+        <td>string</td>
         <td>
           <br/>
         </td>
@@ -1377,7 +1377,7 @@ GrafanaNotificationChannelSpec defines the desired state of GrafanaNotificationC
         <td><b>json</b></td>
         <td>string</td>
         <td>
-          INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file<br/>
+          <br/>
         </td>
         <td>true</td>
       </tr><tr>


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
- adds `omitempty` to `dashboard.spec.json`
- regenerates api-docs
- fixes misplaced comments in structs, adding descriptions where they aren't supposed to be
- Set serviceAccountName: grafana-operator-controller-manager

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
