### PR TITLE
[fix]: Update image repository

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: grafana-operator
       containers:
         - name: grafana-operator
-          image: quay.io/grafana-operator/grafana-operator:v4.0.1
+          image: quay.io/integreatly/grafana-operator:v4.0.1'
           ports:
             - containerPort: 60000
               name: metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: grafana-operator
       containers:
         - name: grafana-operator
-          image: quay.io/integreatly/grafana-operator:v4.0.1'
+          image: quay.io/integreatly/grafana-operator:v4.0.1
           ports:
             - containerPort: 60000
               name: metrics


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->

Hi,
 I think the correct value should be `quay.io/integreatly/grafana-operator:v4.0.1'` integreatly instead of _grafana-operator_. Right?
I'm getting *ImagePullBackOff* when trying to pull the latest version.

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
Unable to pull the latest docker image.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [x] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
