### PR TITLE
Set correct replace in OLM config for v4.0.2

### DIFF
--- a/bundle/manifests/grafana-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/grafana-operator.clusterserviceversion.yaml
@@ -4,8 +4,16 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    categories: Monitoring
+    certified: "False"
+    containerImage: quay.io/grafana-operator/grafana-operator:v4.0.2
+    createdAt: "2021-11-22T10:34:12Z"
+    description: A Kubernetes Operator based on the Operator SDK for creating and
+      managing Grafana instances
     operators.operatorframework.io/builder: operator-sdk-v1.13.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/grafana-operator/grafana-operator
+    support: grafana-operator
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -344,5 +352,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: grafana-operator.v4.0.0
+  replaces: grafana-operator.v4.0.1
   version: 4.0.2

--- a/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
@@ -85,6 +85,14 @@ metadata:
       }
       ]
     capabilities: Basic Install
+    categories: Monitoring
+    certified: "False"
+    containerImage: quay.io/grafana-operator/grafana-operator:v4.0.2
+    createdAt: "2021-11-22T10:34:12Z"
+    description: A Kubernetes Operator based on the Operator SDK for creating and
+      managing Grafana instances
+    repository: https://github.com/grafana-operator/grafana-operator
+    support: grafana-operator
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -159,5 +167,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: grafana-operator.v4.0.0
+  replaces: grafana-operator.v4.0.1
   version: 0.0.0


### PR DESCRIPTION
v4.0.2 is replaces v4.0.1 and not v4.0.0


## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
Missed one value when creating the tag. Sadly this won't be part of 4.0.2 tag but it won't create any issues for operatorhub.io. I have manually updated this change in the PR.