### PR TITLE
Add node to cluster rbac rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,14 @@ If you want to develop/build/test the operator, here are some instructions how t
 ## Debug
 
 We have documented a few steps to help you debug the [grafana-operator](documentation/debug.md).
+
+## FAQ
+
+Q: Why does grafana-operator cluster role have access to nodes?
+
+A: This is a way for the operator-sdk to check if the node where the operator is running is feeling okay.
+   If it's not okay it can give away the lease to another pod faster.
+
+Q: Why can't the operator controle multiple grafana instances?
+
+A: We are currently working on multi-Namespace support.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,6 +10,8 @@ spec:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -42,6 +42,7 @@ var log = logf.Log.WithName(ControllerName)
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets;serviceaccounts;services;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReconcileGrafana) SetupWithManager(mgr ctrl.Manager) error {

--- a/deploy/manifests/latest/deployment.yaml
+++ b/deploy/manifests/latest/deployment.yaml
@@ -28,6 +28,8 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/deploy/manifests/latest/rbac.yaml
+++ b/deploy/manifests/latest/rbac.yaml
@@ -75,6 +75,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get


### PR DESCRIPTION
## Description
Solves #629, the rbac config is needed to make the leader election
notice faster if a pod is down due to a node is having issues.

## Relevant issues/tickets
#629 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [X] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer

## Verification steps

- k apply -k config/install
- Wait and see that the operator starts
- Update the deployment, for example set log level to debug in: https://github.com/grafana-operator/grafana- 
 operator/blob/master/config/default/manager_auth_proxy_patch.yaml
- Follow the logs of the current deployment
- k apply -k config/install
- The new operator will get the lease and start working
