### PR TITLE
Stop using leader-elect, use deployment recreate

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,6 +10,8 @@ spec:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -24,5 +24,4 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
         - "--zap-log-level=error"

--- a/deploy/manifests/latest/deployment.yaml
+++ b/deploy/manifests/latest/deployment.yaml
@@ -28,6 +28,8 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -48,7 +50,6 @@ spec:
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
         - --zap-log-level=error
         command:
         - /manager


### PR DESCRIPTION
## Description
Solves #629, currently leader-elect is broken so for now we disable it.
In the future we will most likley re-enable it again.

## Relevant issues/tickets
#629 
#631 
#620 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer

## Verification steps
- k apply -k deploy/manifests
- Wait and see that the operator starts
- Update the deployment, for example set log level to debug in `deploy/manifests/latest/deployment.yaml`
- k apply -k deploy/manifests

The operator will be recreated without any issues and won't complain about missing node access.
