### PR TITLE
Added OpenShift specific permissions to set custom host for route

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -151,6 +151,7 @@ rules:
   - route.openshift.io
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - create
   - delete

--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -40,7 +40,7 @@ var log = logf.Log.WithName(ControllerName)
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets;serviceaccounts;services;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=route.openshift.io,resources=route;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -40,7 +40,7 @@ var log = logf.Log.WithName(ControllerName)
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets;serviceaccounts;services;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=route;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 
 // SetupWithManager sets up the controller with the Manager.

--- a/deploy/manifests/latest/rbac.yaml
+++ b/deploy/manifests/latest/rbac.yaml
@@ -192,6 +192,7 @@ rules:
   - route.openshift.io
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Description

When using custom host for Grafana's ingress at OpenShift, Grafana provisioning is failing with insufficient permissions error:

```yaml
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana
spec:
  ingress:
    enabled: true
    hostname: grafana.apps.openshift-cluster.com  # <-- custom host
  ...
status:
  message: >-
    Route.route.openshift.io "grafana-route" is invalid: spec.host: Forbidden:
    you do not have permission to set the host field of the route
  phase: failing
```

To allow Grafana's controller to edit custom host in OpenShift's routes, it should have access to `routes/custom-host` resource. 

## Type of change

-  [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [x] Verified independently on a cluster by reviewer

## Verification steps

1. Install Grafana Operator from OpenShift's Operator Hub (`v4.1.0` at the moment)
2. Create Grafana CR with custom `spec.ingress.hostname`
3. Grafana instance will not be created because of insufficient permissions