### PR TITLE
Fix a typo in the README: Developement => Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Represents a Grafana datasource. See [the documentation](./documentation/datasou
 
 Represents a Grafana notifier. See [the documentation](./documentation/notifiers.md) for a description of properties supported in the spec.
 
-## Developement and Local Deployment
+## Development and Local Deployment
 
 ### Using the Makefile
 


### PR DESCRIPTION
Fix a typo in the README: Developement => Development.
