### PR TITLE
fix dashboard custom folder delete error

### DIFF
--- a/controllers/grafanadashboard/grafana_client.go
+++ b/controllers/grafanadashboard/grafana_client.go
@@ -347,7 +347,7 @@ func (r *GrafanaClientImpl) DeleteDashboardByUID(UID string) (GrafanaResponse, e
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 404 {
 		return response, fmt.Errorf(
 			"error deleting dashboard, expected status 200 but got %v",
 			resp.StatusCode)
@@ -483,7 +483,7 @@ func (r *GrafanaClientImpl) DeleteFolder(deleteID *int64) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 404 {
 		return fmt.Errorf(
 			"error deleting folder, expected status 200 but got %v",
 			resp.StatusCode)

--- a/controllers/grafanadashboard/grafanadashboard_controller.go
+++ b/controllers/grafanadashboard/grafanadashboard_controller.go
@@ -383,6 +383,20 @@ func (r *GrafanaDashboardReconciler) reconcileDashboards(request reconcile.Reque
 				log.Log.Error(err, "delete dashboard folder failed", "dashboard.folderId", *dashboard.FolderId)
 			}
 		}
+
+		emptyFolder := true
+		for _, dashboardFromList := range namespaceDashboards.Items {
+			if dashboardFromList.Spec.CustomFolderName == dashboard.FolderName {
+				emptyFolder = false
+				break
+			}
+		}
+
+		if emptyFolder {
+			if err = grafanaClient.DeleteFolder(dashboard.FolderId); err != nil {
+				log.Log.Error(err, "delete dashboard folder failed", "dashboard.folderId", *dashboard.FolderId)
+			}
+		}
 	}
 
 	return reconcile.Result{Requeue: false}, nil


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
* Allows operator to ignore 404 errors when deleting dashboards and custom folders
* Added logic to allow Operator to delete empty custom folders when dashboard deleted
## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
Resolves issue [#648](https://github.com/grafana-operator/grafana-operator/issues/648)
## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
Verified on CRC running locally
1. Deploy a Grafana CR (the example deploy/examples/Grafana.yaml can be used) to your namespace

2. Add two dashboards with the same custom folder (the example deploy/examples/dashboards/DashboardWithCustomFolder.yaml can be used) to your namespace by deploying CRs

3. Run the Operator against your namespace and allow time for Operator to setup completely

4. Ensure dashboards and custom folder have been created by checking Grafana service/route. Both dashboards should be located in the same custom folder.
![Screenshot from 2021-12-22 10-49-02](https://user-images.githubusercontent.com/86788705/147081365-5f65957e-03df-4ebd-ad1a-278db2c271e2.png)

5. Delete one of the dashboard CRs using 
```
oc delete -f <dashboard-cr-location> -n <your-namespace>
```
or equivalent. Ensure that the relevant dashboard is removed but custom folder remains containing the second dashboard.

6. Operator logs should NOT note any 404 errors

7. Delete the remaining dashboard using 
```
oc delete -f <dashboard-cr-location> -n <your-namespace>
```
or equivalent. The remaining dashboard should be removed. The now empty custom folder should also be removed.

8. Operator logs should NOT note any 404 errors