### PR TITLE
feat: added support for flag overrides using environment variables

### DIFF
--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -90,6 +90,15 @@ The operator accepts a number of flags that can be passed in the `args` section 
 
 See `deploy/operator.yaml` for an example.
 
+The Grafana image URL and tag, and Grafana Plugins Init container image and tag can also be overridden using environment
+variables - to support deployment through OLM:
+
+* `GRAFANA_IMAGE_URL`: overrides the Grafana tag. See `controller_config.go` for default.
+* `GRAFANA_IMAGE_TAG`: overrides the Grafana tag. See `controller_config.go` for default.
+* `GRAFANA_PLUGINS_INIT_CONTAINER_IMAGE_URL`: overrides the Grafana Plugins Init Container image, defaults
+  to `quay.io/integreatly/grafana_plugins_init`.
+* `GRAFANA_PLUGINS_INIT_CONTAINER_IMAGE_TAG`: overrides the Grafana Plugins Init Container tag, defaults to `0.0.3`.
+
 ## Deploying Grafana
 
 Create a custom resource of type `Grafana`, or use the one in `deploy/examples/Grafana.yaml`.

--- a/main.go
+++ b/main.go
@@ -148,6 +148,20 @@ func main() { // nolint
 	controllerConfig.AddConfigItem(grafanaconfig.ConfigDashboardLabelSelector, "")
 	controllerConfig.AddConfigItem(grafanaconfig.ConfigJsonnetBasePath, flagJsonnetLocation)
 
+	// Check config is given through env variables - to support OLM installations
+	if flagImage == "" {
+		controllerConfig.AddConfigItem(grafanaconfig.ConfigGrafanaImage, os.Getenv("GRAFANA_IMAGE_URL"))
+	}
+	if flagImageTag == "" {
+		controllerConfig.AddConfigItem(grafanaconfig.ConfigGrafanaImageTag, os.Getenv("GRAFANA_IMAGE_TAG"))
+	}
+	if flagPluginsInitContainerImage == "" {
+		controllerConfig.AddConfigItem(grafanaconfig.ConfigPluginsInitContainerImage, os.Getenv("GRAFANA_PLUGINS_INIT_CONTAINER_IMAGE_URL"))
+	}
+	if flagPluginsInitContainerTag == "" {
+		controllerConfig.AddConfigItem(grafanaconfig.ConfigPluginsInitContainerTag, os.Getenv("GRAFANA_PLUGINS_INIT_CONTAINER_IMAGE_TAG"))
+	}
+
 	// Get the namespaces to scan for dashboards
 	// It's either the same namespace as the controller's or it's all namespaces if the
 	// --scan-all flag has been passed


### PR DESCRIPTION
## Description
Added support for overriding Grafana image/tag and plugins image/tag through environment variables.

This is needed to allow configuration overrides when installing the operator in OpenShift 4.x using OLM, as the Subscription resource doesn't allow for adding command line arguments to the deployed operator.

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ x] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
In OpenShift when deploying using Subscription, add a section as follows:
```
 config:
    env:
    - name: GRAFANA_IMAGE_URL
      value: someregistry.com/somegrafana
```

Verify that the Grafana deployments created uses the specified container image url.