### PR TITLE
fix: reintroduce login duration

### DIFF
--- a/controllers/config/grafanaIni.go
+++ b/controllers/config/grafanaIni.go
@@ -381,7 +381,9 @@ func (i *GrafanaIni) cfgAuth(config map[string][]string) map[string][]string {
 	var items []string
 	items = appendStr(items, "login_cookie_name", i.cfg.Auth.LoginCookieName)
 	items = appendInt(items, "login_maximum_inactive_lifetime_days", i.cfg.Auth.LoginMaximumInactiveLifetimeDays)
+	items = appendStr(items, "login_maximum_inactive_lifetime_duration", i.cfg.Auth.LoginMaximumInactiveLifetimeDuration)
 	items = appendInt(items, "login_maximum_lifetime_days", i.cfg.Auth.LoginMaximumLifetimeDays)
+	items = appendStr(items, "login_maximum_lifetime_duration", i.cfg.Auth.LoginMaximumLifetimeDuration)
 	items = appendInt(items, "token_rotation_interval_minutes", i.cfg.Auth.TokenRotationIntervalMinutes)
 	items = appendBool(items, "disable_login_form", i.cfg.Auth.DisableLoginForm)
 	items = appendBool(items, "disable_signout_menu", i.cfg.Auth.DisableSignoutMenu)

--- a/controllers/config/grafanaIni.go
+++ b/controllers/config/grafanaIni.go
@@ -387,9 +387,9 @@ func (i *GrafanaIni) cfgAuth(config map[string][]string) map[string][]string {
 	items = appendInt(items, "token_rotation_interval_minutes", i.cfg.Auth.TokenRotationIntervalMinutes)
 	items = appendBool(items, "disable_login_form", i.cfg.Auth.DisableLoginForm)
 	items = appendBool(items, "disable_signout_menu", i.cfg.Auth.DisableSignoutMenu)
+	items = appendBool(items, "sigv4_auth_enabled", i.cfg.Auth.SigV4AuthEnabled)
 	items = appendStr(items, "signout_redirect_url", i.cfg.Auth.SignoutRedirectUrl)
 	items = appendBool(items, "oauth_auto_login", i.cfg.Auth.OauthAutoLogin)
-	items = appendBool(items, "sigv4_auth_enabled", i.cfg.Auth.SigV4AuthEnabled)
 	config["auth"] = items
 
 	return config

--- a/controllers/config/grafanaIni_test.go
+++ b/controllers/config/grafanaIni_test.go
@@ -21,6 +21,15 @@ var (
 	ServeFromSubPath = false
 	RouterLogging    = false
 
+	// Auth
+	loginMaximumInactiveLifetimeDays = 1
+	loginMaximumLifetimeDays         = 2
+	tokenRotationIntervalMinutes     = 10
+	disableLoginForm                 = true
+	disableSignoutMenu               = true
+	sigV4AuthEnabled                 = true
+	oauthAutoLogin                   = true
+
 	// AuthAzureAd
 	azureAdEnabled = true
 	allowSignUp    = false
@@ -60,6 +69,19 @@ var testGrafanaConfig = v1alpha1.GrafanaConfig{
 		Password: "password",
 		SslMode:  "sslMode",
 	},
+	Auth: &v1alpha1.GrafanaConfigAuth{
+		LoginCookieName:                      "grafana_session",
+		LoginMaximumInactiveLifetimeDays:     &loginMaximumInactiveLifetimeDays,
+		LoginMaximumInactiveLifetimeDuration: "4h",
+		LoginMaximumLifetimeDays:             &loginMaximumLifetimeDays,
+		LoginMaximumLifetimeDuration:         "8h",
+		TokenRotationIntervalMinutes:         &tokenRotationIntervalMinutes,
+		DisableLoginForm:                     &disableLoginForm,
+		DisableSignoutMenu:                   &disableSignoutMenu,
+		SigV4AuthEnabled:                     &sigV4AuthEnabled,
+		SignoutRedirectUrl:                   "https://RedirectURL.com",
+		OauthAutoLogin:                       &oauthAutoLogin,
+	},
 	AuthAzureAD: &v1alpha1.GrafanaConfigAuthAzureAD{
 		Enabled:        &azureAdEnabled,
 		ClientId:       "Client",
@@ -87,7 +109,20 @@ var testGrafanaConfig = v1alpha1.GrafanaConfig{
 	},
 }
 
-var testIni = `[auth.azuread]
+var testIni = `[auth]
+disable_login_form = true
+disable_signout_menu = true
+login_cookie_name = grafana_session
+login_maximum_inactive_lifetime_days = 1
+login_maximum_inactive_lifetime_duration = 4h
+login_maximum_lifetime_days = 2
+login_maximum_lifetime_duration = 8h
+oauth_auto_login = true
+signout_redirect_url = https://RedirectURL.com
+sigv4_auth_enabled = true
+token_rotation_interval_minutes = 10
+
+[auth.azuread]
 allow_sign_up = false
 allowed_domains = azure.com
 auth_url = https://AuthURL.com
@@ -191,6 +226,28 @@ func TestCfgServer(t *testing.T) {
 			"cert_file = /mnt/cert.crt",
 			"cert_key = /mnt/cert.key",
 			"router_logging = false",
+		},
+	}
+	require.Equal(t, config, testConfig)
+}
+
+func TestCfgAuth(t *testing.T) {
+	i := NewGrafanaIni(&testGrafanaConfig)
+	config := map[string][]string{}
+	config = i.cfgAuth(config)
+	testConfig := map[string][]string{
+		"auth": {
+			"login_cookie_name = grafana_session",
+			"login_maximum_inactive_lifetime_days = 1",
+			"login_maximum_inactive_lifetime_duration = 4h",
+			"login_maximum_lifetime_days = 2",
+			"login_maximum_lifetime_duration = 8h",
+			"token_rotation_interval_minutes = 10",
+			"disable_login_form = true",
+			"disable_signout_menu = true",
+			"sigv4_auth_enabled = true",
+			"signout_redirect_url = https://RedirectURL.com",
+			"oauth_auto_login = true",
 		},
 	}
 	require.Equal(t, config, testConfig)


### PR DESCRIPTION
## Description

Many months ago, I added support for `login_maximum_inactive_lifetime_duration` and `login_maximum_lifetime_duration` in https://github.com/grafana-operator/grafana-operator/pull/345. It was quite important to have this functionality since grafana still doesn't fully track validity of OIDC sessions, which leads to forwarding stale tokens to data sources unless the right settings are made in both grafana and Keycloak. - Other parameters `login_maximum_lifetime_days` and `login_maximum_inactive_lifetime_days`, don't give enough flexibility in the period of time.

Haven't used grafana-operator since I changed companies. Recently, I rebuilt a local lab with a fresh grafana-operator, and noticed today that grafana was sending stale tokens, which shouldn't have been the case since I had all the right settings in place from previous labs.

Further digging showed that the configmap generated by grafana-operator did not contain  `login_maximum_inactive_lifetime_duration` and `login_maximum_lifetime_duration`. In source code, those get added to a struct, but not dumped into grafana.ini.

The suggested change brings back full support for the parameters.

P.S. Please, let me know if tests are needed. I haven't explored that side, though I guess it all should be doable in a timely manner.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have added a test case that will be used to verify my changes 

## Verification steps

1. Add the following settings to grafana CR:

```yaml
      auth:
        login_maximum_inactive_lifetime_duration: 4h
        login_maximum_lifetime_duration: 8h
```

2. You should see those settings in the cm with grafana.ini:

```
apiVersion: v1
data:
  grafana.ini: |+
[...]
    [auth]
    login_maximum_inactive_lifetime_duration = 4h
    login_maximum_lifetime_duration = 8h
```
