### PR TITLE
Add support for timezone in jsonData for MySQL data source

### DIFF
--- a/api/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/api/integreatly/v1alpha1/grafanadatasource_types.go
@@ -183,6 +183,8 @@ type GrafanaDataSourceJsonData struct {
 	UseProxy          bool   `json:"useProxy,omitempty"`
 	ShowOffline       bool   `json:"showOffline,omitempty"`
 	AllowInfraExplore bool   `json:"allowInfraExplore,omitempty"`
+	// Extra field for MySQL data source
+	Timezone string `json:"timezone,omitempty"`
 }
 
 type GrafanaDataSourceJsonDerivedFields struct {

--- a/config/crd/bases/integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/integreatly.org_grafanadatasources.yaml
@@ -231,6 +231,9 @@ spec:
                           type: string
                         timescaledb:
                           type: boolean
+                        timezone:
+                          description: Extra field for MySQL data source
+                          type: string
                         tlsAuth:
                           type: boolean
                         tlsAuthWithCACert:

--- a/deploy/manifests/latest/crds.yaml
+++ b/deploy/manifests/latest/crds.yaml
@@ -339,6 +339,9 @@ spec:
                           type: string
                         timescaledb:
                           type: boolean
+                        timezone:
+                          description: Extra field for MySQL data source
+                          type: string
                         tlsAuth:
                           type: boolean
                         tlsAuthWithCACert:

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -1004,6 +1004,13 @@ GrafanaDataSourceJsonData contains the most common json options See https://graf
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>timezone</b></td>
+        <td>string</td>
+        <td>
+          Extra field for MySQL data source<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>tlsAuth</b></td>
         <td>boolean</td>
         <td>


### PR DESCRIPTION
## Description

Add support for the new field timezone, in jsonData, used by the MySQL data source:
https://grafana.com/docs/grafana/latest/datasources/mysql/

## Relevant issues/tickets
None

## Type of change

Not sure if this is breaking or not. It whitelists one field in jsonData in the datasource CRD.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
- Create datasource with the field timestamp in jsonData and verify that the timezone is present in the datasource.