### PR TITLE
Whitelist fields for Grafana Clickhouse datasource

### DIFF
--- a/api/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/api/integreatly/v1alpha1/grafanadatasource_types.go
@@ -183,6 +183,10 @@ type GrafanaDataSourceJsonData struct {
 	UseProxy          bool   `json:"useProxy,omitempty"`
 	ShowOffline       bool   `json:"showOffline,omitempty"`
 	AllowInfraExplore bool   `json:"allowInfraExplore,omitempty"`
+	// Fields for Grafana Clickhouse data sources
+	Server   string `json:"server,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Username string `json:"username,omitempty"`
 }
 
 type GrafanaDataSourceJsonDerivedFields struct {

--- a/config/crd/bases/integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/integreatly.org_grafanadatasources.yaml
@@ -192,6 +192,8 @@ spec:
                           type: boolean
                         organization:
                           type: string
+                        port:
+                          type: integer
                         postgresVersion:
                           type: integer
                         search:
@@ -199,6 +201,9 @@ spec:
                             hide:
                               type: boolean
                           type: object
+                        server:
+                          description: Fields for Grafana Clickhouse data sources
+                          type: string
                         serviceMap:
                           properties:
                             datasourceUid:
@@ -273,6 +278,8 @@ spec:
                           type: boolean
                         useYandexCloudAuthorization:
                           type: boolean
+                        username:
+                          type: string
                         version:
                           type: string
                         xHeaderKey:

--- a/deploy/manifests/latest/crds.yaml
+++ b/deploy/manifests/latest/crds.yaml
@@ -300,6 +300,8 @@ spec:
                           type: boolean
                         organization:
                           type: string
+                        port:
+                          type: integer
                         postgresVersion:
                           type: integer
                         search:
@@ -307,6 +309,9 @@ spec:
                             hide:
                               type: boolean
                           type: object
+                        server:
+                          description: Fields for Grafana Clickhouse data sources
+                          type: string
                         serviceMap:
                           properties:
                             datasourceUid:
@@ -381,6 +386,8 @@ spec:
                           type: boolean
                         useYandexCloudAuthorization:
                           type: boolean
+                        username:
+                          type: string
                         version:
                           type: string
                         xHeaderKey:

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -892,6 +892,13 @@ GrafanaDataSourceJsonData contains the most common json options See https://graf
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>port</b></td>
+        <td>integer</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>postgresVersion</b></td>
         <td>integer</td>
         <td>
@@ -903,6 +910,13 @@ GrafanaDataSourceJsonData contains the most common json options See https://graf
         <td>object</td>
         <td>
           <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>server</b></td>
+        <td>string</td>
+        <td>
+          Fields for Grafana Clickhouse data sources<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1076,6 +1090,13 @@ GrafanaDataSourceJsonData contains the most common json options See https://graf
       </tr><tr>
         <td><b>useYandexCloudAuthorization</b></td>
         <td>boolean</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>username</b></td>
+        <td>string</td>
         <td>
           <br/>
         </td>


### PR DESCRIPTION
## Description

Whitelist the jsonData fields used by the [grafana-clickhouse-datasource](https://grafana.com/grafana/plugins/grafana-clickhouse-datasource/).

## Relevant issues/tickets
- https://github.com/grafana-operator/grafana-operator/issues/688

## Type of change

I'm not sure if this is breaking or not. It whitelists 3 fields in jsonData in the datasource CRD.

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer
