### PR TITLE
Enable restricted network builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG UBI_MINIMAL_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:8.4
 ARG UBI_MICRO_IMAGE=registry.access.redhat.com/ubi8/ubi-micro:8.4
 
 # Build the manager binary
+# hadolint ignore=DL3006
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
 ARG TARGETARCH
@@ -35,8 +36,10 @@ RUN GOPROXY=${GOPROXY} \
     GOARCH=${TARGETARCH} \
     go build -a -o manager main.go
 
+# hadolint ignore=DL3006
 FROM --platform=${TARGETPLATFORM} ${UBI_MINIMAL_IMAGE} as ubi-minimal
 
+# hadolint ignore=DL3006
 FROM --platform=${TARGETPLATFORM} ${UBI_MICRO_IMAGE}
 
 # copy Root CA bundle from ubi-minimal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
+ARG BUILDER_IMAGE
+ARG UBI_MINIMAL_IMAGE
+ARG UBI_MICRO_IMAGE
+
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} golang:1.16 as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.16} as builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -22,9 +26,9 @@ COPY version/ version/
 # Build
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal:8.4 as ubi-minimal
+FROM --platform=${TARGETPLATFORM} ${UBI_MINIMAL_IMAGE:-registry.access.redhat.com/ubi8/ubi-minimal:8.4} as ubi-minimal
 
-FROM --platform=${TARGETPLATFORM} registry.access.redhat.com/ubi8/ubi-micro:8.4
+FROM --platform=${TARGETPLATFORM} ${UBI_MICRO_IMAGE:-registry.access.redhat.com/ubi8/ubi-micro:8.4}
 
 # copy Root CA bundle from ubi-minimal
 COPY --from=ubi-minimal /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG BUILDER_IMAGE
-ARG UBI_MINIMAL_IMAGE
-ARG UBI_MICRO_IMAGE
+ARG BUILDER_IMAGE=golang:1.16
+ARG UBI_MINIMAL_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:8.4
+ARG UBI_MICRO_IMAGE=registry.access.redhat.com/ubi8/ubi-micro:8.4
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE:-golang:1.16} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -16,8 +16,8 @@ COPY go.mod ./
 COPY go.sum ./
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN GOPROXY=${GOPROXY:-} \
-    GOPRIVATE=${GOPRIVATE:-} \
+RUN GOPROXY=${GOPROXY} \
+    GOPRIVATE=${GOPRIVATE} \
     go mod download
 
 # Copy the go source
@@ -28,16 +28,16 @@ COPY internal/ internal/
 COPY version/ version/
 
 # Build
-RUN GOPROXY=${GOPROXY:-} \
-    GOPRIVATE=${GOPRIVATE:-} \
+RUN GOPROXY=${GOPROXY} \
+    GOPRIVATE=${GOPRIVATE} \
     CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build -a -o manager main.go
 
-FROM --platform=${TARGETPLATFORM} ${UBI_MINIMAL_IMAGE:-registry.access.redhat.com/ubi8/ubi-minimal:8.4} as ubi-minimal
+FROM --platform=${TARGETPLATFORM} ${UBI_MINIMAL_IMAGE} as ubi-minimal
 
-FROM --platform=${TARGETPLATFORM} ${UBI_MICRO_IMAGE:-registry.access.redhat.com/ubi8/ubi-micro:8.4}
+FROM --platform=${TARGETPLATFORM} ${UBI_MICRO_IMAGE}
 
 # copy Root CA bundle from ubi-minimal
 COPY --from=ubi-minimal /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
## Description
When building the grafana operator from source within a network restricted environment, being able to use local images and GOPROXY/GOPRIVATE is a requirement.

## Relevant issues/tickets
#707 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
