### PR TITLE
Documentation Clusterserviceversion manifest supported Red Hat

### DIFF
--- a/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
@@ -92,7 +92,7 @@ metadata:
     description: A Kubernetes Operator based on the Operator SDK for creating and
       managing Grafana instances
     repository: https://github.com/grafana-operator/grafana-operator
-    support: grafana-operator
+    support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported


### PR DESCRIPTION
## Description
This is the standard that we have been using in OLM.
Changing this will remove a manual step in the release.

This is how it looks in OLM:

https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/5c964fcff569a9131ceebc48f28869c4b9713860/operators/grafana-operator/4.2.0/grafana-operator.clusterserviceversion.yaml#L16

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
