### PR TITLE
fix: update default init container image to fix cve

### DIFF
--- a/controllers/config/controller_config.go
+++ b/controllers/config/controller_config.go
@@ -25,7 +25,7 @@ const (
 	GrafanaProvisioningDashboardsPath       = "/etc/grafana/provisioning/dashboards"
 	GrafanaProvisioningNotifiersPath        = "/etc/grafana/provisioning/notifiers"
 	PluginsInitContainerImage               = "quay.io/grafana-operator/grafana_plugins_init"
-	PluginsInitContainerTag                 = "0.0.5"
+	PluginsInitContainerTag                 = "0.0.6"
 	PluginsUrl                              = "https://grafana.com/api/plugins/%s/versions/%s"
 	RequeueDelay                            = time.Second * 10
 	SecretsMountDir                         = "/etc/grafana-secrets/" // #nosec G101


### PR DESCRIPTION
## Description

update init container default image


## Verification steps

1. deploy operator from the branch and create one of the example dashboards containing plugins
2. ensure that the plugin is installed correctly
