### PR TITLE
Configurable RequeueDelay

### DIFF
--- a/controllers/config/controller_config.go
+++ b/controllers/config/controller_config.go
@@ -27,7 +27,6 @@ const (
 	PluginsInitContainerImage               = "quay.io/grafana-operator/grafana_plugins_init"
 	PluginsInitContainerTag                 = "0.0.6"
 	PluginsUrl                              = "https://grafana.com/api/plugins/%s/versions/%s"
-	RequeueDelay                            = time.Second * 10
 	SecretsMountDir                         = "/etc/grafana-secrets/" // #nosec G101
 	ConfigMapsMountDir                      = "/etc/grafana-configmaps/"
 	ConfigRouteWatch                        = "watch.routes"
@@ -38,9 +37,10 @@ const (
 
 type ControllerConfig struct {
 	*sync.Mutex
-	Values     map[string]interface{}
-	Plugins    map[string]v1alpha1.PluginList
-	Dashboards map[string][]*v1alpha1.GrafanaDashboardRef
+	Values       map[string]interface{}
+	Plugins      map[string]v1alpha1.PluginList
+	Dashboards   map[string][]*v1alpha1.GrafanaDashboardRef
+	RequeueDelay time.Duration
 }
 
 var instance *ControllerConfig
@@ -49,10 +49,11 @@ var once sync.Once
 func GetControllerConfig() *ControllerConfig {
 	once.Do(func() {
 		instance = &ControllerConfig{
-			Mutex:      &sync.Mutex{},
-			Values:     map[string]interface{}{},
-			Plugins:    map[string]v1alpha1.PluginList{},
-			Dashboards: map[string][]*v1alpha1.GrafanaDashboardRef{},
+			Mutex:        &sync.Mutex{},
+			Values:       map[string]interface{}{},
+			Plugins:      map[string]v1alpha1.PluginList{},
+			Dashboards:   map[string][]*v1alpha1.GrafanaDashboardRef{},
+			RequeueDelay: time.Second * 10,
 		}
 	})
 	return instance

--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -233,7 +233,7 @@ func (r *ReconcileGrafana) manageError(cr *grafanav1alpha1.Grafana, issue error,
 		GrafanaReady: false,
 	}
 
-	return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
+	return reconcile.Result{RequeueAfter: r.Config.RequeueDelay}, nil
 }
 
 // Try to find a suitable url to grafana
@@ -325,5 +325,5 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 
 	log.V(1).Info("desired cluster state met")
 
-	return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
+	return reconcile.Result{RequeueAfter: r.Config.RequeueDelay}, nil
 }

--- a/controllers/grafanadashboard/grafanadashboard_controller.go
+++ b/controllers/grafanadashboard/grafanadashboard_controller.go
@@ -92,7 +92,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, request ctrl
 
 	getClient, err := r.getClient()
 	if err != nil {
-		return reconcile.Result{RequeueAfter: config.RequeueDelay}, err
+		return reconcile.Result{RequeueAfter: config.GetControllerConfig().RequeueDelay}, err
 	}
 
 	// Initial request?
@@ -103,7 +103,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, request ctrl
 	// Check if the label selectors are available yet. If not then the grafana controller
 	// has not finished initializing and we can't continue. Reschedule for later.
 	if r.state.DashboardSelectors == nil {
-		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
+		return reconcile.Result{RequeueAfter: config.GetControllerConfig().RequeueDelay}, nil
 	}
 
 	// Fetch the GrafanaDashboard instance
@@ -172,7 +172,7 @@ func SetupWithManager(mgr ctrl.Manager, r reconcile.Reconciler, namespace string
 	}
 
 	ref := r.(*GrafanaDashboardReconciler) // nolint
-	ticker := time.NewTicker(config.RequeueDelay)
+	ticker := time.NewTicker(config.GetControllerConfig().RequeueDelay)
 	sendEmptyRequest := func() {
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{

--- a/controllers/grafananotificationchannel/grafananotificationchannel_controller.go
+++ b/controllers/grafananotificationchannel/grafananotificationchannel_controller.go
@@ -104,7 +104,7 @@ func SetupWithManager(mgr ctrl.Manager, r reconcile.Reconciler, namespace string
 	}
 
 	var ref = r.(*GrafanaNotificationChannelReconciler)
-	ticker := time.NewTicker(config.RequeueDelay)
+	ticker := time.NewTicker(config.GetControllerConfig().RequeueDelay)
 	sendEmptyRequest := func() {
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -165,7 +165,7 @@ func (r *GrafanaNotificationChannelReconciler) Reconcile(context context.Context
 	grafanaClient, err := r.getClient()
 	if err != nil {
 		// we handle the error by requeing, safe to ignore nilerr return
-		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil //nolint:nilerr
+		return reconcile.Result{RequeueAfter: config.GetControllerConfig().RequeueDelay}, nil //nolint:nilerr
 	}
 
 	// Initial request?
@@ -176,7 +176,7 @@ func (r *GrafanaNotificationChannelReconciler) Reconcile(context context.Context
 	// Check if the label selectors are available yet. If not then the grafana controller
 	// has not finished initializing and we can't continue. Reschedule for later.
 	if r.state.DashboardSelectors == nil {
-		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
+		return reconcile.Result{RequeueAfter: config.GetControllerConfig().RequeueDelay}, nil
 	}
 
 	// Fetch the GrafanaNotificationChannel instance

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -87,6 +87,7 @@ The operator accepts a number of flags that can be passed in the `args` section 
 * `--zap-level=n`: set the logging level for the operator, leaving out this flag will only log Errors and error related
   info, current options are:
   * `--zap-level=1`: show all Info level logs
+* `--requeue-delay=n`: set how often the resync of the grafana resources towards the grafana instance should happen in seconds. The default is 10s.
 
 See `deploy/operator.yaml` for an example.
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
Allows the current default of refreshing dashboards every 10 seconds to be configured. This might be useful in the situation where something isn't configured correctly, or there are a huge amount of dashboards such that the operator is constantly busy updating dashboards which might make it hard to understand what is happening.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
Tested on a home cluster and seems to work as intended.