### PR TITLE
Fix bug introduced by #690

### DIFF
--- a/controllers/config/controller_config.go
+++ b/controllers/config/controller_config.go
@@ -158,16 +158,15 @@ func (c *ControllerConfig) GetDashboards(namespace string) []*v1alpha1.GrafanaDa
 		return c.Dashboards[namespace]
 	}
 
-	return []*v1alpha1.GrafanaDashboardRef{}
-}
+	dashboards := []*v1alpha1.GrafanaDashboardRef{}
 
-func (c *ControllerConfig) GetAllDashboards() []*v1alpha1.GrafanaDashboardRef {
-	c.Lock()
-	defer c.Unlock()
-
-	var dashboards []*v1alpha1.GrafanaDashboardRef
-	for _, ds := range c.Dashboards {
-		dashboards = append(dashboards, ds...)
+	// The periodic resync in grafanadashboard.GrafanaDashboardReconciler rely on the convention
+	// that an empty namespace means all of them, so we follow that rule here.
+	if namespace == "" {
+		for _, ds := range c.Dashboards {
+			dashboards = append(dashboards, ds...)
+		}
+		return dashboards
 	}
 
 	return dashboards

--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -283,7 +283,7 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 	// Only update the status if the dashboard controller had a chance to sync the cluster
 	// dashboards first. Otherwise reuse the existing dashboard config from the CR.
 	if r.Config.GetConfigBool(config.ConfigGrafanaDashboardsSynced, false) {
-		cr.Status.InstalledDashboards = r.Config.GetAllDashboards()
+		cr.Status.InstalledDashboards = r.Config.GetDashboards("")
 	}
 
 	instance := &grafanav1alpha1.Grafana{}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
When the GetDashboards function is called for the re-sync it gets called with the namespace specified as the empty string, this wasn't accounted for in #690. So, after #690 the reconciliation of dashboards (for the periodic re-sync) started getting an empty list of known dashboards which then caused any checking of existing dashboards to fail. 
## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
Some people have noticed that this started happening in 4.3.0 (myself included): https://github.com/grafana-operator/grafana-operator/issues/686#issuecomment-1114753394

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
Built and tested on my home cluster and seems to have solved the issue of new versions being created each sync period.
Docker image available here: `ghcr.io/addreas/grafana-operator:v4.3.0-690-bugfix`