### PR TITLE
Add nil check for service & service ports before iterating

### DIFF
--- a/controllers/model/grafanaService.go
+++ b/controllers/model/grafanaService.go
@@ -70,9 +70,11 @@ func GetGrafanaPort(cr *v1alpha1.Grafana) int {
 func getServicePorts(cr *v1alpha1.Grafana, currentState *v1.Service) []v1.ServicePort {
 	intPort := int32(GetGrafanaPort(cr))
 	nodePort := int32(0)
-	for _, nPort := range cr.Spec.Service.Ports {
-		if nPort.Port == 3000 {
-			nodePort = nPort.NodePort
+	if cr.Spec.Service != nil && cr.Spec.Service.Ports != nil {
+		for _, nPort := range cr.Spec.Service.Ports {
+			if nPort.Port == 3000 {
+				nodePort = nPort.NodePort
+			}
 		}
 	}
 	defaultPorts := []v1.ServicePort{

--- a/controllers/model/grafanaService.go
+++ b/controllers/model/grafanaService.go
@@ -70,7 +70,7 @@ func GetGrafanaPort(cr *v1alpha1.Grafana) int {
 func getServicePorts(cr *v1alpha1.Grafana, currentState *v1.Service) []v1.ServicePort {
 	intPort := int32(GetGrafanaPort(cr))
 	nodePort := int32(0)
-	if cr.Spec.Service != nil && cr.Spec.Service.Ports != nil {
+	if cr.Spec.Service != nil {
 		for _, nPort := range cr.Spec.Service.Ports {
 			if nPort.Port == 3000 {
 				nodePort = nPort.NodePort


### PR DESCRIPTION
## Description
Simple fix: add a nil check for service & service ports before iterating in GetServicePorts

## Relevant issues/tickets
https://github.com/grafana-operator/grafana-operator/issues/746

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
