### PR TITLE
Return empty path for termination passthrough

### DIFF
--- a/controllers/model/grafanaRoute.go
+++ b/controllers/model/grafanaRoute.go
@@ -21,7 +21,7 @@ func GetPath(cr *v1alpha1.Grafana) string {
 		return "/"
 	}
 
-	if cr.Spec.Ingress.Termination == "passthrough" {
+	if cr.Spec.Ingress.Termination == v1.TLSTerminationPassthrough {
 		return ""
 	}
 

--- a/controllers/model/grafanaRoute.go
+++ b/controllers/model/grafanaRoute.go
@@ -21,6 +21,10 @@ func GetPath(cr *v1alpha1.Grafana) string {
 		return "/"
 	}
 
+	if cr.Spec.Ingress.Termination == "passthrough" {
+		return ""
+	}
+
 	if cr.Spec.Ingress.Path == "" {
 		return "/"
 	}


### PR DESCRIPTION
## Description
Fixed to return empty path when ingress termination is "passthrough".
Passthrough mode doesn't require path setting.

## Relevant issues/tickets
https://github.com/grafana-operator/grafana-operator/issues/766

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
0. Check environment

```
$ oc version
Client Version: 4.9.21
Server Version: 4.10.15
Kubernetes Version: v1.23.5+3afdacb
```

1. Create Grafana custom resouce like bellow.

```yaml
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana-sample
spec:
  ingress:
    enabled: True
    termination: passthrough
  config:
    security:
      admin_user: admin
      admin_password: admin
```

2. Check generated route resouce

```
oc get route grafana-route -o yaml
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  annotations:
    openshift.io/host.generated: "true"
  creationTimestamp: "2022-06-08T14:01:35Z"
  name: grafana-route
  namespace: grafana-operator-system
  ownerReferences:
  - apiVersion: integreatly.org/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Grafana
    name: grafana-sample
    uid: 17cd2c5c-553d-4363-a12e-1c77b448f94b
  resourceVersion: "178223"
  uid: a4100a36-a8e0-4307-b1c1-3ddbb56c3672
spec:
  host: grafana-route-grafana-operator-system.apps.xxxx.com
  port:
    targetPort: 3000
  tls:
    termination: passthrough
  to:
    kind: Service
    name: grafana-service
    weight: 100
  wildcardPolicy: None
status:
  ingress:
  - conditions:
    - lastTransitionTime: "2022-06-08T14:01:35Z"
      status: "True"
      type: Admitted
    host: grafana-route-grafana-operator-system.apps.xxxx.com
    routerCanonicalHostname: router-default.apps.xxxx.com
    routerName: default
    wildcardPolicy: None
```