### PR TITLE
Add noProxy setting n spec.deployment.httpProxy of Grafana resource

### DIFF
--- a/api/integreatly/v1alpha1/grafana_types.go
+++ b/api/integreatly/v1alpha1/grafana_types.go
@@ -126,6 +126,7 @@ type GrafanaHttpProxy struct {
 	Enabled   bool   `json:"enabled"`
 	URL       string `json:"url,omitempty"`
 	SecureURL string `json:"secureUrl,omitempty"`
+	NoProxy   string `json:"noProxy,omitempty"`
 }
 
 // GrafanaIngress provides a means to configure the ingress created

--- a/config/crd/bases/integreatly.org_grafanas.yaml
+++ b/config/crd/bases/integreatly.org_grafanas.yaml
@@ -4410,6 +4410,8 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      noProxy:
+                        type: string
                       secureUrl:
                         type: string
                       url:

--- a/controllers/model/grafanaDeployment.go
+++ b/controllers/model/grafanaDeployment.go
@@ -578,6 +578,12 @@ func getContainers(cr *v1alpha1.Grafana, configHash, dsHash string) []v13.Contai
 				Value: cr.Spec.Deployment.HttpProxy.SecureURL,
 			})
 		}
+		if cr.Spec.Deployment.HttpProxy.NoProxy != "" {
+			envVars = append(envVars, v13.EnvVar{
+				Name:  "NO_PROXY",
+				Value: cr.Spec.Deployment.HttpProxy.NoProxy,
+			})
+		}
 	}
 
 	if cr.Spec.Deployment != nil && cr.Spec.Deployment.Env != nil {

--- a/controllers/model/grafanaDeployment_test.go
+++ b/controllers/model/grafanaDeployment_test.go
@@ -1,0 +1,69 @@
+package model
+
+import (
+	"testing"
+
+	grafanav1alpha1 "github.com/grafana-operator/grafana-operator/v4/api/integreatly/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrafanaDeployment_httpProxy(t *testing.T) {
+	t.Run("noProxy is setting", func(t *testing.T) {
+		cr := &grafanav1alpha1.Grafana{
+			Spec: grafanav1alpha1.GrafanaSpec{
+				Deployment: &grafanav1alpha1.GrafanaDeployment{
+					HttpProxy: &grafanav1alpha1.GrafanaHttpProxy{
+						Enabled:   true,
+						URL:       "http://1.2.3.4",
+						SecureURL: "http://1.2.3.4",
+						NoProxy:   ".svc.cluster.local,.svc",
+					},
+				},
+			},
+		}
+		deployment := GrafanaDeployment(cr, "", "")
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name != "grafana" {
+				continue
+			}
+
+			noProxyExist := false
+			for _, env := range container.Env {
+				if env.Name == "NO_PROXY" {
+					noProxyExist = true
+					assert.Equal(t, ".svc.cluster.local,.svc", env.Value)
+				}
+			}
+			assert.True(t, noProxyExist)
+		}
+	})
+
+	t.Run("noProxy is not setting", func(t *testing.T) {
+		cr := &grafanav1alpha1.Grafana{
+			Spec: grafanav1alpha1.GrafanaSpec{
+				Deployment: &grafanav1alpha1.GrafanaDeployment{
+					HttpProxy: &grafanav1alpha1.GrafanaHttpProxy{
+						Enabled:   true,
+						URL:       "http://1.2.3.4",
+						SecureURL: "http://1.2.3.4",
+					},
+				},
+			},
+		}
+		deployment := GrafanaDeployment(cr, "", "")
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name != "grafana" {
+				continue
+			}
+
+			noProxyExist := false
+			for _, env := range container.Env {
+				if env.Name == "NO_PROXY" {
+					noProxyExist = true
+				}
+			}
+			assert.False(t, noProxyExist)
+		}
+	})
+}

--- a/controllers/model/grafanaRoute.go
+++ b/controllers/model/grafanaRoute.go
@@ -21,6 +21,10 @@ func GetPath(cr *v1alpha1.Grafana) string {
 		return "/"
 	}
 
+	if cr.Spec.Ingress.Termination == v1.TLSTerminationPassthrough {
+		return ""
+	}
+
 	if cr.Spec.Ingress.Path == "" {
 		return "/"
 	}

--- a/deploy/manifests/latest/crds.yaml
+++ b/deploy/manifests/latest/crds.yaml
@@ -5005,6 +5005,8 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      noProxy:
+                        type: string
                       secureUrl:
                         type: string
                       url:

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -11764,6 +11764,13 @@ GrafanaHttpProxy provides a means to configure the Grafana deployment to use an 
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>noProxy</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>secureUrl</b></td>
         <td>string</td>
         <td>


### PR DESCRIPTION
## Description
Add noProxy setting in `spec.deployment.httpProxy` of Grafana resource.

## Relevant issues/tickets
#736

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] This change requires a documentation update 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

```
$ cat <<EOF | kubectl apply -f -
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana-sample-with-proxy
spec:
  ingress:
    enabled: True
  config:
    security:
      admin_user: admin
      admin_password: admin
  deployment:
    httpProxy:
      enabled: true
      url: http://192.168.1.10:8080
      secureUrl: http://192.168.1.10:8080
      noProxy: ".cluster.local,.svc,.example.com,localhost"
EOF

grafana.integreatly.org/grafana-sample-with-proxy created

$ kubectl get pod -o yaml | grep -A1 NO_PROXY
      - name: NO_PROXY
        value: .cluster.local,.svc,.example.com,localhost
```
