### PR TITLE
feat: add support for queryTimeout in datasources

### DIFF
--- a/api/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/api/integreatly/v1alpha1/grafanadatasource_types.go
@@ -87,6 +87,7 @@ type GrafanaDataSourceFields struct {
 // GrafanaDataSourceJsonData contains the most common json options
 // See https://grafana.com/docs/administration/provisioning/#datasources
 type GrafanaDataSourceJsonData struct {
+	QueryTimeout            string `json:"queryTimeout,omitempty"`
 	OauthPassThru           bool   `json:"oauthPassThru,omitempty"`
 	TlsAuth                 bool   `json:"tlsAuth,omitempty"`
 	TlsAuthWithCACert       bool   `json:"tlsAuthWithCACert,omitempty"`

--- a/bundle/manifests/integreatly.org_grafanadatasources.yaml
+++ b/bundle/manifests/integreatly.org_grafanadatasources.yaml
@@ -202,6 +202,8 @@ spec:
                           type: integer
                         postgresVersion:
                           type: integer
+                        queryTimeout:
+                          type: string
                         search:
                           properties:
                             hide:

--- a/config/crd/bases/integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/integreatly.org_grafanadatasources.yaml
@@ -204,6 +204,8 @@ spec:
                           type: integer
                         postgresVersion:
                           type: integer
+                        queryTimeout:
+                          type: string
                         search:
                           properties:
                             hide:

--- a/deploy/manifests/latest/crds.yaml
+++ b/deploy/manifests/latest/crds.yaml
@@ -312,6 +312,8 @@ spec:
                           type: integer
                         postgresVersion:
                           type: integer
+                        queryTimeout:
+                          type: string
                         search:
                           properties:
                             hide:

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -920,6 +920,13 @@ GrafanaDataSourceJsonData contains the most common json options See https://graf
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>queryTimeout</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#grafanadatasourcespecdatasourcesindexjsondatasearch">search</a></b></td>
         <td>object</td>
         <td>


### PR DESCRIPTION
## Description

This PR adds support for `queryTimeout` (part of `jsonData`) in datasources.

## Relevant issues/tickets

Closes: #782 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

1. Add a datasource with a custom `queryTimeout` in `jsonData`:

```yaml
apiVersion: integreatly.org/v1alpha1
kind: GrafanaDataSource
metadata:
  name: example-grafanadatasource
spec:
  name: middleware.yaml
  datasources:
    - name: Prometheus
      type: prometheus
      access: proxy
      url: http://prometheus-service:9090
      isDefault: true
      version: 1
      editable: true
      jsonData:
        tlsSkipVerify: true
        timeInterval: "5s"
        queryTimeout: 30s
```

2. In Grafana, inspect the datasource:

<img width="670" alt="image" src="https://user-images.githubusercontent.com/46579601/177036347-74e99ddb-f951-40b8-8aef-1faea58692f7.png">
