### PR TITLE
fix: return correct message about unsupported protocol

### DIFF
--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -275,13 +275,13 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 		protocol := "http"
 
 		if cr.Spec.Config.Server != nil {
-			switch protocol = cr.Spec.Config.Server.Protocol; protocol {
+			switch cr.Spec.Config.Server.Protocol {
 			case "", "http":
 				protocol = "http"
 			case "https":
 				protocol = "https"
 			default:
-				return "", fmt.Errorf("server protocol %v is not supported, please use either http or https", protocol)
+				return "", fmt.Errorf("server protocol %v is not supported, please use either http or https", cr.Spec.Config.Server.Protocol)
 			}
 		}
 

--- a/controllers/grafana/grafana_controller.go
+++ b/controllers/grafana/grafana_controller.go
@@ -275,7 +275,7 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 		protocol := "http"
 
 		if cr.Spec.Config.Server != nil {
-			switch cr.Spec.Config.Server.Protocol {
+			switch protocol = cr.Spec.Config.Server.Protocol; protocol {
 			case "", "http":
 				protocol = "http"
 			case "https":


### PR DESCRIPTION
## Description

There's a cosmetic bug in `getGrafanaAdminUrl` - if unsupported protocol is chosen through `config.server.protocol`, the operator would always complain about `http` instead of actual protocol: `server protocol http is not supported, please use either http or https`.

The PR fixes that.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

Deploy grafana with the following config:

```yaml
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: example-grafana
spec:
  client:
    preferService: true
  config:
    server:
      protocol: unknown-protocol
```

You should see a reference to `unknown-protocol` in the error message:
`grafana-operator-846d554b57-vvxgs grafana-operator 2022-07-20T16:28:21.238Z	DEBUG	controller-runtime.manager.events	Warning	{"object": {"kind":"Grafana","namespace":"monitoring","name":"example-grafana","uid":"f218c504-fd0a-4fc2-8e6f-5519f369c97c","apiVersion":"integreatly.org/v1alpha1","resourceVersion":"503482"}, "reason": "ProcessingError", "message": "server protocol unknown-protocol is not supported, please use either http or https"}`