### PR TITLE
Update replaces for 4.5.1 manifests

### DIFF
--- a/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
@@ -168,5 +168,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: grafana-operator.v4.4.1
+  replaces: grafana-operator.v4.5.0
   version: 0.0.0


### PR DESCRIPTION
## Description
An error in the prepare 4.5.1 commit. I fix this now so I don't forget it to the next release as well.
