### PR TITLE
add support to set datasource timeout

### DIFF
--- a/api/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/api/integreatly/v1alpha1/grafanadatasource_types.go
@@ -101,6 +101,8 @@ type GrafanaDataSourceFields struct {
 // GrafanaDataSourceJsonData contains the most common json options
 // See https://grafana.com/docs/administration/provisioning/#datasources
 type GrafanaDataSourceJsonData struct {
+	// HTTP Request timeout in seconds. Overrides dataproxy.timeout option
+	Timeout                 int                `json:"timeout,omitempty"`
 	QueryTimeout            string             `json:"queryTimeout,omitempty"`
 	OauthPassThru           bool               `json:"oauthPassThru,omitempty"`
 	TlsAuth                 bool               `json:"tlsAuth,omitempty"`

--- a/config/crd/bases/integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/integreatly.org_grafanadatasources.yaml
@@ -259,6 +259,10 @@ spec:
                           type: string
                         timeInterval:
                           type: string
+                        timeout:
+                          description: HTTP Request timeout in seconds. Overrides
+                            dataproxy.timeout option
+                          type: integer
                         timescaledb:
                           type: boolean
                         timezone:

--- a/deploy/manifests/latest/crds.yaml
+++ b/deploy/manifests/latest/crds.yaml
@@ -421,6 +421,10 @@ spec:
                           type: string
                         timeInterval:
                           type: string
+                        timeout:
+                          description: HTTP Request timeout in seconds. Overrides
+                            dataproxy.timeout option
+                          type: integer
                         timescaledb:
                           type: boolean
                         timezone:

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -1205,6 +1205,13 @@ GrafanaDataSourceJsonData contains the most common json options See https://graf
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>timeout</b></td>
+        <td>integer</td>
+        <td>
+          HTTP Request timeout in seconds. Overrides dataproxy.timeout option<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>timescaledb</b></td>
         <td>boolean</td>
         <td>


### PR DESCRIPTION

This addition allows setting the data-source HTTP client [timeout](https://github.com/grafana/grafana/blob/6d5bdf12e850b3df2a8b6d26f39c277b226f4c85/pkg/services/datasources/service/datasource.go#L503), to work around situations where the default timeout is to small. 

Note, I choose the type `int` for the timeout as this is what the Grafana [code primarily expects](https://github.com/grafana/grafana/blob/6d5bdf12e850b3df2a8b6d26f39c277b226f4c85/pkg/services/datasources/service/datasource.go#L503), technically `string` or `intstr.IntOrString` would also work.

Signed-off-by: Alexander Berger <alex.berger@nexxiot.com>

## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [x] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
