### PR TITLE
fix: ignore case for folder names in grafana responses

### DIFF
--- a/controllers/grafanadashboard/grafana_client.go
+++ b/controllers/grafanadashboard/grafana_client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -206,7 +207,7 @@ func (r *GrafanaClientImpl) CreateOrUpdateFolder(folderInputName string) (Grafan
 	}
 
 	for _, folder := range allfolders {
-		if folder.Title == folderInputName {
+		if strings.EqualFold(folder.Title, folderInputName) {
 			return folder, nil
 		}
 	}

--- a/controllers/grafanadashboardfolder/grafana_client.go
+++ b/controllers/grafanadashboardfolder/grafana_client.go
@@ -132,7 +132,7 @@ func (r *GrafanaClientImpl) FindOrCreateFolder(folderName string) (GrafanaFolder
 	}
 
 	for _, folder := range existingFolders {
-		if folder.Title == folderName {
+		if strings.EqualFold(folder.Title, folderName) {
 			return folder, nil
 		}
 	}


### PR DESCRIPTION
## Description

As it turned out in #829, grafana is case-insensitive for folder names. Thus, the suggestion is to ignore the case in functions that try to find an already-existing folder.

## Relevant issues/tickets

#829

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

1. Deploy two dashboards with the same folder names written in different case (e.g. `platform` and `Platform`)
=> Both dashboards should appear in grafana interface, no logs with the 409 code in operator logs.