### PR TITLE
fix: respect hardcoded uids in all types of dashboards

### DIFF
--- a/controllers/grafanadashboard/dashboard_pipeline.go
+++ b/controllers/grafanadashboard/dashboard_pipeline.go
@@ -98,7 +98,7 @@ func (r *DashboardPipelineImpl) ProcessDashboard(knownHash string, folderId *int
 	// always assigned by Grafana. If there is one, we ignore it
 	r.Board["id"] = nil
 
-	// Overwrite in case any user provided uid exists
+	// Generate uid if needed
 
 	r.Board["uid"] = r.Dashboard.UID()
 	r.Board["folderId"] = folderId
@@ -142,6 +142,16 @@ func (r *DashboardPipelineImpl) obtainJson() error {
 	if r.Dashboard.Spec.Url != "" && r.Dashboard.Spec.GrafanaCom != nil {
 		return errors.New("both dashboard url and grafana.com source specified")
 	}
+
+	// If a dashboard comes not from .Spec.Json, we'll fail to detect hardcoded uids through GrafanaDashboard.UID().
+	// To workaround that, we should sync r.Dashboard.Spec.Json with r.JSON in case the former is empty.
+	syncJSON := func() {
+		if r.Dashboard.Spec.Json == "" {
+			r.Dashboard.Spec.Json = r.JSON
+		}
+	}
+
+	defer syncJSON()
 
 	var returnErr error
 


### PR DESCRIPTION
## Description

We have an issue with extracting hardcoded `uid` for certain types of dashboards.

The process goes approximately like this:

1. `GrafanaDashboard` relies on `UID()` to get the value.
2. `UID()` inspects contents of `Parse()`
2.1. if the result is empty or doesn't contain a hardcoded uid, `UID()` generates its own value.
2.2. If dashboard spec containing a hardcoded uid is returned, then it'll be used.

And the tricky part comes from the fact that `DashboardPipelineImpl` populates `r.JSON` when pulling, e.g. url-based dashboards, while `Parse()` inspects only `Spec.GzipJson` and `Spec.Json`

This PR fixes the behaviour by making `obtainJson()` to save a copy to `Spec.Json` if the latter is empty.

And since uid will be different for certain types of dashboards, it'll potentially cause reconciliation issues.

Now, we have two non-destructive ways:
- Keep things as is and leave this PR just for the history purposes.
- Maybe introduce a feature flag that would make the controller obtain both hardcoded uid and a self-generated one and then drop dashboards with the latter;
 
Personally, in the context of upcoming v5, I'd prefer not to merge the PR to avoid breaking things, uid handling in v5 will be different anyway.

## Relevant issues/tickets

Fixes: #818 

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

1. Deploy something like:

```
apiVersion: integreatly.org/v1alpha1
kind: GrafanaDashboard
metadata:
  name: grafana-dashboard-from-url
  labels:
    app.kubernetes.io/instance: grafana-operator
spec:
  url: https://grafana.com/api/dashboards/11176/revisions/1/download
```

4. Dashboard should have the same uid as specified in the dashboard spec.