### PR TITLE
fix: dashboard cache (sequence of actions)

### DIFF
--- a/controllers/grafanadashboard/dashboard_pipeline.go
+++ b/controllers/grafanadashboard/dashboard_pipeline.go
@@ -35,9 +35,7 @@ const (
 	SourceTypeUnknown SourceType = 3
 )
 
-var (
-	grafanaComDashboardApiUrlRoot string = "https://grafana.com/api/dashboards"
-)
+var grafanaComDashboardApiUrlRoot string = "https://grafana.com/api/dashboards"
 
 type DashboardPipeline interface {
 	ProcessDashboard(knownHash string, folderId *int64, folderName string, forceRecreate bool) ([]byte, error)
@@ -304,13 +302,13 @@ func (r *DashboardPipelineImpl) loadDashboardFromURL(source string) error {
 		return err
 	}
 
+	r.refreshDashboard()
 	r.Dashboard.Status = v1alpha1.GrafanaDashboardStatus{
 		ContentCache:     content,
 		ContentTimestamp: &metav1.Time{Time: time.Now()},
 		ContentUrl:       source,
 	}
 
-	r.refreshDashboard()
 	if err := r.Client.Status().Update(r.Context, r.Dashboard); err != nil {
 		if !k8serrors.IsConflict(err) {
 			return fmt.Errorf("failed to update status with content for dashboard %s/%s: %w", r.Dashboard.Namespace, r.Dashboard.Name, err)


### PR DESCRIPTION
## Description

With url-based dashboards, a few status fields are supposed to be used for caching. It doesn't happen though, because the `r.refreshDashboard()` call (fetches the latest version of CR) is made right after the `r.Dashboard.Status` is prepared, effectively dropping all cache data.

This PR restores correct sequence of actions.

## Relevant issues/tickets

Fixes: #832

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

1. Deploy something like:

```
apiVersion: integreatly.org/v1alpha1
kind: GrafanaDashboard
metadata:
  name: grafana-dashboard-from-url
  labels:
    app.kubernetes.io/instance: grafana-operator
spec:
  url: https://grafana.com/api/dashboards/11176/revisions/1/download
```

2. Cache data in CR status fields should get populated.