### PR TITLE
Fix containerSecurityContext for init-container

### DIFF
--- a/controllers/model/grafanaDeployment.go
+++ b/controllers/model/grafanaDeployment.go
@@ -678,6 +678,7 @@ func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 			TerminationMessagePath:   "/dev/termination-log",
 			TerminationMessagePolicy: "File",
 			ImagePullPolicy:          "IfNotPresent",
+			SecurityContext:          getContainerSecurityContext(cr),
 		},
 	}
 }


### PR DESCRIPTION
## Description
Documentation states that containerSecurityContext should also affect the init-container, this patch should actually apply this previously missing feature.

Documentation already contains this as a NOTE under https://github.com/grafana-operator/grafana-operator/blob/master/documentation/deploy_grafana.md#configuring-the-deployment

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
Ensure that deployment.containerSecurityContext is propagated to initContainer.
grafana.yaml
```
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana
spec:
  client:
    preferService: true
  ingress:
    enabled: False
  config:
    log:
      mode: "console"
      level: "error"
    log.frontend:
      enabled: true
    auth:
      disable_login_form: False
      disable_signout_menu: True
    auth.anonymous:
      enabled: True
  service:
    name: "grafana"
    labels:
      app.kubernetes.io/name: grafana
      type: "grafana"
  dashboardLabelSelector:
    - matchExpressions:
        - { key: app, operator: In, values: [grafana] }
  resources:
    limits:
      cpu: 200m
      memory: 200Mi
    requests:
      cpu: 100m
      memory: 100Mi
  deployment:
    containerSecurityContext:
      allowPrivilegeEscalation: false
```