### PR TITLE
fix: double-lock when multiple dashboards have the same UID

### DIFF
--- a/controllers/config/controller_config.go
+++ b/controllers/config/controller_config.go
@@ -45,8 +45,10 @@ type ControllerConfig struct {
 	RequeueDelay time.Duration
 }
 
-var instance *ControllerConfig
-var once sync.Once
+var (
+	instance *ControllerConfig
+	once     sync.Once
+)
 
 func GetControllerConfig() *ControllerConfig {
 	once.Do(func() {
@@ -169,16 +171,18 @@ func (c *ControllerConfig) InvalidateDashboards() {
 	}
 }
 
-func (c *ControllerConfig) RemoveDashboard(hash string) {
-	for ns := range c.Dashboards {
-		if i, exists := c.HasDashboard(ns, hash); exists {
-			c.Lock()
-			defer c.Unlock()
-			list := c.Dashboards[ns]
-			list[i] = list[len(list)-1]
-			list = list[:len(list)-1]
-			c.Dashboards[ns] = list
-		}
+func (c *ControllerConfig) RemoveDashboard(dashboard *v1alpha1.GrafanaDashboardRef) {
+	c.Lock()
+	defer c.Unlock()
+
+	ns := dashboard.Namespace
+	uid := dashboard.UID
+
+	if i, exists := c.HasDashboard(ns, uid); exists {
+		list := c.Dashboards[ns]
+		list[i] = list[len(list)-1]
+		list = list[:len(list)-1]
+		c.Dashboards[ns] = list
 	}
 }
 

--- a/controllers/config/controller_config.go
+++ b/controllers/config/controller_config.go
@@ -93,6 +93,8 @@ func (c *ControllerConfig) SetPluginsFor(dashboard *v1alpha1.GrafanaDashboard) {
 }
 
 func (c *ControllerConfig) RemovePluginsFor(dashboard *v1alpha1.GrafanaDashboardRef) {
+	c.Lock()
+	defer c.Unlock()
 	id := c.GetDashboardId(dashboard.Namespace, dashboard.Name)
 	delete(c.Plugins, id)
 }

--- a/controllers/grafanadashboard/grafanadashboard_controller.go
+++ b/controllers/grafanadashboard/grafanadashboard_controller.go
@@ -379,7 +379,7 @@ func (r *GrafanaDashboardReconciler) reconcileDashboards(request reconcile.Reque
 		log.Log.Info(fmt.Sprintf("delete result was %v", *status.Message))
 
 		r.config.RemovePluginsFor(dashboard)
-		r.config.RemoveDashboard(dashboard.UID)
+		r.config.RemoveDashboard(dashboard)
 
 		// Refresh the list of known dashboards after the dashboard has been removed
 		knownDashboards = r.config.GetDashboards(request.Namespace)


### PR DESCRIPTION
## Description

As it was described in #860, controller tries to acquire a second lock when there are multiple dashboards with the same UID and one of those gets deleted.

## Relevant issues/tickets

Closes: #860

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->

Follow the steps described in #860:
1. Deploy two dashboards with the same uid;
2. Remove of of those;
3. Reconciliation should not get stuck.