### PR TITLE
Generic OAuth - add use_pkce field

### DIFF
--- a/api/integreatly/v1alpha1/grafana_types.go
+++ b/api/integreatly/v1alpha1/grafana_types.go
@@ -426,6 +426,7 @@ type GrafanaConfigAuthGenericOauth struct {
 	Scopes               string `json:"scopes,omitempty" ini:"scopes,omitempty"`
 	AuthUrl              string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
 	TokenUrl             string `json:"token_url,omitempty" ini:"token_url,omitempty"`
+	UsePkce              *bool  `json:"use_pkce,omitempty" ini:"use_pkce,omitempty"`
 	ApiUrl               string `json:"api_url,omitempty" ini:"api_url,omitempty"`
 	TeamsURL             string `json:"teams_url,omitempty" ini:"teams_url,omitempty"`
 	TeamIds              string `json:"team_ids,omitempty" ini:"team_ids,omitempty"`

--- a/api/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/api/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -494,6 +494,11 @@ func (in *GrafanaConfigAuthGenericOauth) DeepCopyInto(out *GrafanaConfigAuthGene
 		*out = new(bool)
 		**out = **in
 	}
+	if in.UsePkce != nil {
+		in, out := &in.UsePkce, &out.UsePkce
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RoleAttributeStrict != nil {
 		in, out := &in.RoleAttributeStrict, &out.RoleAttributeStrict
 		*out = new(bool)

--- a/bundle/manifests/integreatly.org_grafanas.yaml
+++ b/bundle/manifests/integreatly.org_grafanas.yaml
@@ -199,6 +199,9 @@ spec:
                         type: boolean
                       token_url:
                         type: string
+                      use_pkce:
+                        nullable: true
+                        type: boolean
                     type: object
                   auth.github:
                     properties:

--- a/config/crd/bases/integreatly.org_grafanas.yaml
+++ b/config/crd/bases/integreatly.org_grafanas.yaml
@@ -201,6 +201,8 @@ spec:
                         type: boolean
                       token_url:
                         type: string
+                      use_pkce:
+                        type: boolean
                     type: object
                   auth.github:
                     properties:

--- a/controllers/config/grafanaIni.go
+++ b/controllers/config/grafanaIni.go
@@ -514,6 +514,7 @@ func (i *GrafanaIni) cfgAuthGenericOauth(config map[string][]string) map[string]
 	items = appendBool(items, "allow_sign_up", i.cfg.AuthGenericOauth.AllowSignUp)
 	items = appendStr(items, "client_id", i.cfg.AuthGenericOauth.ClientId)
 	items = appendStr(items, "client_secret", i.cfg.AuthGenericOauth.ClientSecret)
+	items = appendBool(items, "use_pkce", i.cfg.AuthGenericOauth.UsePkce)
 	items = appendStr(items, "scopes", i.cfg.AuthGenericOauth.Scopes)
 	items = appendStr(items, "auth_url", i.cfg.AuthGenericOauth.AuthUrl)
 	items = appendStr(items, "token_url", i.cfg.AuthGenericOauth.TokenUrl)

--- a/controllers/config/grafanaIni_test.go
+++ b/controllers/config/grafanaIni_test.go
@@ -39,6 +39,7 @@ var (
 	genericOauthAllowSignUp           = true
 	genericOauthRoleAttributeStrict   = true
 	genericOauthTLSSkipVerifyInsecure = true
+	genericOauthUsePkce               = true
 
 	// AuthGitlab
 	gitlabEnabled                 = true
@@ -143,6 +144,7 @@ var testGrafanaConfig = v1alpha1.GrafanaConfig{
 		Scopes:                "ScopesOauth",
 		AuthUrl:               "https://AuthURLOauth.com",
 		TokenUrl:              "https://TokenURLOauth.com",
+		UsePkce:               &genericOauthUsePkce,
 		ApiUrl:                "https://ApiURLOauth.com",
 		TeamsURL:              "https://TeamsURLOauth.com",
 		TeamIds:               "1,2",
@@ -234,6 +236,7 @@ tls_client_cert = /genericOauth/clientCert
 tls_client_key = /genericOauth/clientKey
 tls_skip_verify_insecure = true
 token_url = https://TokenURLOauth.com
+use_pkce = true
 
 [auth.gitlab]
 allow_assign_grafana_admin = true

--- a/deploy/manifests/latest/crds.yaml
+++ b/deploy/manifests/latest/crds.yaml
@@ -942,6 +942,8 @@ spec:
                         type: boolean
                       token_url:
                         type: string
+                      use_pkce:
+                        type: boolean
                     type: object
                   auth.github:
                     properties:

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -3092,6 +3092,13 @@ GrafanaConfig is the configuration for grafana
           <br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>use_pkce</b></td>
+        <td>boolean</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 


### PR DESCRIPTION
## Description
Very similar to https://github.com/grafana-operator/grafana-operator/pull/889

adds `pkce` support: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/#pkce

✅ built and tested with image: `maciekm/grafana-operator:use-pkce-1`

## Relevant issues/tickets
https://github.com/grafana-operator/grafana-operator/issues/877

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] This change requires a documentation update 
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer
