### PR TITLE
explicitly set `automountServiceAccountToken` to "true"

### DIFF
--- a/deploy/base/serviceaccount.yaml
+++ b/deploy/base/serviceaccount.yaml
@@ -4,3 +4,4 @@ kind: ServiceAccount
 metadata:
   name: grafana-operator-controller-manager
   namespace: default
+automountServiceAccountToken: true

--- a/deploy/helm/grafana-operator/templates/serviceaccount.yaml
+++ b/deploy/helm/grafana-operator/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: true
 {{- end }}


### PR DESCRIPTION
explicitly set `automountServiceAccountToken` to "true" in grafana-operator-controller-manager Serviceaccount for Operator

Since it's needed to connect to the in-cluster k8s API. The k8s default is "true", but it might be "false" on customized clusters, leading to failure when deploying the operator.