### PR TITLE
extend kubeRbacProxy helm configuration

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -44,7 +44,7 @@ It's easier to just manage this configuration outside of the operator.
 | kubeRbacProxy.args | list | `["--secure-listen-address=0.0.0.0:8443","--upstream=http://127.0.0.1:8080/","--logtostderr=true","--v=10"]` | kubeRbacProxy container args |
 | kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in kubeRbacProxy container |
 | kubeRbacProxy.image.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` | The image repository to use in kubeRbacProxy container |
-| kubeRbacProxy.image.tag | string | `"v0.8.0"` | Overrides the image tag whose default is the chart appVersion. |
+| kubeRbacProxy.image.tag | string | `"v0.8.0"` | The image tag to use in kubeRbacProxy container |
 | kubeRbacProxy.livenessProbe | object | `{}` | kubeRbacProxy liveness probe |
 | kubeRbacProxy.readinessProbe | object | `{}` | kubeRbacProxy readyness probe |
 | kubeRbacProxy.resources | object | `{}` | kubeRbacProxy resources |

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -35,34 +35,33 @@ It's easier to just manage this configuration outside of the operator.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` |  |
+| affinity | object | `{}` | pod affinity |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/grafana-operator/grafana-operator"` |  |
-| image.tag | string | `""` |  |
-| imagePullSecrets | list | `[]` |  |
-| kubeRbacProxy.args[0] | string | `"--secure-listen-address=0.0.0.0:8443"` |  |
-| kubeRbacProxy.args[1] | string | `"--upstream=http://127.0.0.1:8080/"` |  |
-| kubeRbacProxy.args[2] | string | `"--logtostderr=true"` |  |
-| kubeRbacProxy.args[3] | string | `"--v=10"` |  |
-| kubeRbacProxy.image | string | `"gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"` | The image to use in kubeRbacProxy container |
-| kubeRbacProxy.imagePullPolicy | string | `"IfNotPresent"` |  |
-| kubeRbacProxy.resources | object | `{}` |  |
-| kubeRbacProxy.service.port | int | `8443` |  |
-| kubeRbacProxy.service.type | string | `"ClusterIP"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in grafana operator container |
+| image.repository | string | `"ghcr.io/grafana-operator/grafana-operator"` | grafana operator image repository |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | image pull secrets |
+| kubeRbacProxy.args | list | `["--secure-listen-address=0.0.0.0:8443","--upstream=http://127.0.0.1:8080/","--logtostderr=true","--v=10"]` | kubeRbacProxy container args |
+| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in kubeRbacProxy container |
+| kubeRbacProxy.image.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` | The image repository to use in kubeRbacProxy container |
+| kubeRbacProxy.image.tag | string | `"v0.8.0"` | Overrides the image tag whose default is the chart appVersion. |
+| kubeRbacProxy.livenessProbe | object | `{}` | kubeRbacProxy liveness probe |
+| kubeRbacProxy.readinessProbe | object | `{}` | kubeRbacProxy readyness probe |
+| kubeRbacProxy.resources | object | `{}` | kubeRbacProxy resources |
+| kubeRbacProxy.securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | kubeRbacProxy securityContext |
+| kubeRbacProxy.service.port | int | `8443` | kubeRbacProxy service port |
+| kubeRbacProxy.service.type | string | `"ClusterIP"` | kubeRbacProxy service type |
 | leaderElect | bool | `false` | If you want to run multiple replicas of the grafana-operator, this is not recommended. |
 | nameOverride | string | `""` |  |
 | namespaceScope | bool | `false` | If the operator should run in namespace-scope or not, if true the operator will only be able to manage instances in the same namespace |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
-| priorityClassName | string | `""` | podPriorityClass |
-| resources | object | `{}` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| securityContext.runAsNonRoot | bool | `true` |  |
+| nodeSelector | object | `{}` | pod node selector |
+| podAnnotations | object | `{}` | pod annotations |
+| podSecurityContext | object | `{}` | pod security context |
+| priorityClassName | string | `""` | pod priority class name |
+| resources | object | `{}` | grafana operator container resources |
+| securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | grafana operator container security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| tolerations | list | `[]` |  |
+| tolerations | list | `[]` | pod tolerations |
 | watchNamespaces | string | `""` | Sets the WATCH_NAMESPACES environment variable, it defines which namespaces the operator should be listening for. By default it's all namespaces, if you only want to listen for the same namespace as the operator is deployed to look at namespaceScope. |

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -23,12 +23,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "grafana-operator.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
@@ -48,19 +52,37 @@ spec:
             httpGet:
               path: /readyz
               port: 8081
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-          imagePullPolicy: IfNotPresent
+          {{- with .Values.kubeRbacProxy.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.kubeRbacProxy.imagePullPolicy }}
           {{- with .Values.kubeRbacProxy.args }}
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-          - containerPort: {{ .Values.kubeRbacProxy.service.port }}
-            name: https
-            protocol: TCP
+            - containerPort: {{ .Values.kubeRbacProxy.service.port }}
+              name: https
+              protocol: TCP
+          {{- with .Values.kubeRbacProxy.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kubeRbacProxy.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kubeRbacProxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
-          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -11,12 +11,16 @@ leaderElect: false
 watchNamespaces: ""
 
 image:
+  # -- grafana operator image repository
   repository: ghcr.io/grafana-operator/grafana-operator
+  # -- The image pull policy to use in grafana operator container
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# -- image pull secrets
 imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -29,12 +33,14 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- pod annotations
 podAnnotations: {}
 
-podSecurityContext:
-  {}
+# -- pod security context
+podSecurityContext: {}
   # fsGroup: 2000
 
+# -- grafana operator container security context
 securityContext:
   capabilities:
     drop:
@@ -42,8 +48,8 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
 
-resources:
-  {}
+# -- grafana operator container resources
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -56,24 +62,50 @@ resources:
   #   memory: 128Mi
 
 kubeRbacProxy:
-  # -- The image to use in kubeRbacProxy container
-  image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-  imagePullPolicy: IfNotPresent
+  image:
+    # -- Overrides the image tag whose default is the chart appVersion.
+    tag: v0.8.0
+    # -- The image repository to use in kubeRbacProxy container
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    # -- The image pull policy to use in kubeRbacProxy container
+    pullPolicy: IfNotPresent
+
+  # -- kubeRbacProxy container args
   args:
     - --secure-listen-address=0.0.0.0:8443
     - --upstream=http://127.0.0.1:8080/
     - --logtostderr=true
     - --v=10
   service:
+    # -- kubeRbacProxy service type
     type: ClusterIP
+    # -- kubeRbacProxy service port
     port: 8443
+
+  # -- kubeRbacProxy resources
   resources: {}
 
-# -- podPriorityClass
+  # -- kubeRbacProxy liveness probe
+  livenessProbe: {}
+  # -- kubeRbacProxy readyness probe
+  readinessProbe: {}
+
+  # -- kubeRbacProxy securityContext
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+
+# -- pod priority class name
 priorityClassName: ""
 
+# -- pod node selector
 nodeSelector: {}
 
+# -- pod tolerations
 tolerations: []
 
+# -- pod affinity
 affinity: {}

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -38,7 +38,6 @@ podAnnotations: {}
 
 # -- pod security context
 podSecurityContext: {}
-  # fsGroup: 2000
 
 # -- grafana operator container security context
 securityContext:
@@ -50,20 +49,10 @@ securityContext:
 
 # -- grafana operator container resources
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 kubeRbacProxy:
   image:
-    # -- Overrides the image tag whose default is the chart appVersion.
+    # -- The image tag to use in kubeRbacProxy container
     tag: v0.8.0
     # -- The image repository to use in kubeRbacProxy container
     repository: gcr.io/kubebuilder/kube-rbac-proxy


### PR DESCRIPTION
The helm config of kube rbac proxy had some unmapped values, which are now correctly mapped.

Also additional properties such as securityContext, liveness- / readynessProbe and reyources can now be defined for the kube rbac proxy container.

