### PR TITLE
Generate grafana crd documentation

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -32,7 +32,8 @@ jobs:
           git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
           git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
           git check-attr --stdin ignore-lint | grep -Ev ': (set|true)$' | cut -d: -f1 |
-          grep -Ev '^(vendor/|third_party/|LICENSES/|.git|api.md|bundle/)' |
+          grep -Ev '^(vendor/|third_party/|LICENSES/|.git|bundle/)' |
+          grep -v api.md |
           xargs grep -nE " +$" |
           reviewdog -efm="%f:%l:%m" \
                 -name="trailing whitespace" \

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -11,12 +11,76 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b #v3.2.0
+      - name: reviewdog
+        uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
+        with:
+          reviewdog_version: latest
 
-      - name: trailing space
-        uses: chainguard-dev/actions/trailing-space@main
-
-      - name: eof-check
-        uses: chainguard-dev/actions/eof-newline@main
+      - name: Trailing Whitespace
+        shell: bash
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          pushd "${GITHUB_WORKSPACE}/" || exit 1
+          echo '::group:: Flagging trailing whitespace with reviewdog 🐶 ...'
+          # Don't fail because of grep
+          set +o pipefail
+          # Exclude generated and vendored files, plus some legacy
+          # paths until we update all .gitattributes
+          git ls-files |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin ignore-lint | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          grep -Ev '^(vendor/|third_party/|LICENSES/|.git|api.md|bundle/)' |
+          xargs grep -nE " +$" |
+          reviewdog -efm="%f:%l:%m" \
+                -name="trailing whitespace" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="true" \
+                -level="error"
+          echo '::endgroup::'
+          popd
+      - name: EOF newline
+        shell: bash
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          pushd "${GITHUB_WORKSPACE}/" || exit 1
+          git status
+          echo '::group:: Flagging missing EOF newlines with reviewdog 🐶 ...'
+          # Don't fail because of misspell
+          set +o pipefail
+          # Lint exclude rule:
+          #  - nothing in vendor/
+          #  - nothing in third_party
+          #  - nothing in .git/
+          #  - no *.ai (Adobe Illustrator) files.
+          LINT_FILES=$(git ls-files |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin ignore-lint | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          grep -Ev '^(vendor/|third_party/|LICENSES/|.git)' |
+          grep -v '\.ai$' |
+          grep -v '\.svg$')
+          for x in $LINT_FILES; do
+            # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file
+            if [[ -f $x && ! ( -s "$x" && -z "$(tail -c 1 $x)" ) ]]; then
+              # We add 1 to `wc -l` here because of this limitation (from the man page):
+              # Characters beyond the final <newline> character will not be included in the line count.
+              echo $x:$((1 + $(wc -l $x | tr -s ' ' | cut -d' ' -f 1))): Missing newline
+            fi
+          done |
+          reviewdog -efm="%f:%l: %m" \
+                -name="EOF Newline" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="true" \
+                -level="error"
+          echo '::endgroup::'
+          popd
 
   go-lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ api-docs: gen-crd-api-reference-docs kustomize
 	@{ \
 	set -e ;\
 	TMP_DIR=$$(mktemp -d) ; \
-	$(KUSTOMIZE) build config/crd -o $$TMP_DIR/crd-output.yaml ;\
+	$(KUSTOMIZE) build config/ -o $$TMP_DIR/crd-output.yaml ;\
 	$(API_REF_GEN) crdoc --resources $$TMP_DIR/crd-output.yaml --output docs/docs/api.md --template frontmatter.tmpl;\
 	}
 

--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -55,22 +55,35 @@ type OperatorReconcileVars struct {
 // GrafanaSpec defines the desired state of Grafana
 type GrafanaSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Config                map[string]map[string]string `json:"config,omitempty"`
-	Ingress               *IngressNetworkingV1         `json:"ingress,omitempty"`
-	Route                 *RouteOpenshiftV1            `json:"route,omitempty"`
-	Service               *ServiceV1                   `json:"service,omitempty"`
-	Deployment            *DeploymentV1                `json:"deployment,omitempty"`
-	PersistentVolumeClaim *PersistentVolumeClaimV1     `json:"persistentVolumeClaim,omitempty"`
-	ServiceAccount        *ServiceAccountV1            `json:"serviceAccount,omitempty"`
-	Client                *GrafanaClient               `json:"client,omitempty"`
-	Jsonnet               *JsonnetConfig               `json:"jsonnet,omitempty"`
-	External              *External                    `json:"external,omitempty"`
+	// Config defines how your grafana ini file should looks like.
+	Config map[string]map[string]string `json:"config,omitempty"`
+	// Ingress sets how the ingress object should look like with your grafana instance.
+	Ingress *IngressNetworkingV1 `json:"ingress,omitempty"`
+	// Route sets how the ingress object should look like with your grafana instance, this only works in Openshift.
+	Route *RouteOpenshiftV1 `json:"route,omitempty"`
+	// Service sets how the service object should look like with your grafana instance, contains a number of defaults.
+	Service *ServiceV1 `json:"service,omitempty"`
+	// Deployment sets how the deployment object should look like with your grafana instance, contains a number of defaults.
+	Deployment *DeploymentV1 `json:"deployment,omitempty"`
+	// PersistentVolumeClaim creates a PVC if you need to attach one to your grafana instance.
+	PersistentVolumeClaim *PersistentVolumeClaimV1 `json:"persistentVolumeClaim,omitempty"`
+	// ServiceAccount sets how the ServiceAccount object should look like with your grafana instance, contains a number of defaults.
+	ServiceAccount *ServiceAccountV1 `json:"serviceAccount,omitempty"`
+	// Client defines how the grafana-operator talks to the grafana instance.
+	Client  *GrafanaClient `json:"client,omitempty"`
+	Jsonnet *JsonnetConfig `json:"jsonnet,omitempty"`
+	// External enables you to configure external grafana instances that is not managed by the operator.
+	External *External `json:"external,omitempty"`
 }
 
 type External struct {
-	URL           string                `json:"url"`
-	ApiKey        *v1.SecretKeySelector `json:"apiKey,omitempty"`
-	AdminUser     *v1.SecretKeySelector `json:"adminUser,omitempty"`
+	// URL of the external grafana instance you want to manage.
+	URL string `json:"url"`
+	// The API key to talk to the external grafana instance, you need to define ether apiKey or adminUser/adminPassword.
+	ApiKey *v1.SecretKeySelector `json:"apiKey,omitempty"`
+	// AdminUser key to talk to the external grafana instance.
+	AdminUser *v1.SecretKeySelector `json:"adminUser,omitempty"`
+	// AdminPassword key to talk to the external grafana instance.
 	AdminPassword *v1.SecretKeySelector `json:"adminPassword,omitempty"`
 }
 
@@ -83,6 +96,7 @@ type GrafanaClient struct {
 	// +nullable
 	TimeoutSeconds *int `json:"timeout,omitempty"`
 	// +nullable
+	// If the operator should send it's request through the grafana instances ingress object instead of through the service.
 	PreferIngress *bool `json:"preferIngress,omitempty"`
 }
 

--- a/config/grafana.integreatly.org_grafanas.yaml
+++ b/config/grafana.integreatly.org_grafanas.yaml
@@ -36,9 +36,13 @@ spec:
             description: GrafanaSpec defines the desired state of Grafana
             properties:
               client:
-                description: GrafanaClient contains the Grafana API client settings
+                description: Client defines how the grafana-operator talks to the
+                  grafana instance.
                 properties:
                   preferIngress:
+                    description: If the operator should send it's request through
+                      the grafana instances ingress object instead of through the
+                      service.
                     nullable: true
                     type: boolean
                   timeout:
@@ -50,9 +54,13 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                description: Config defines how your grafana ini file should looks
+                  like.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               deployment:
+                description: Deployment sets how the deployment object should look
+                  like with your grafana instance, contains a number of defaults.
                 properties:
                   metadata:
                     description: ObjectMeta contains only a [subset of the fields
@@ -8112,9 +8120,12 @@ spec:
                     type: object
                 type: object
               external:
+                description: External enables you to configure external grafana instances
+                  that is not managed by the operator.
                 properties:
                   adminPassword:
-                    description: SecretKeySelector selects a key of a Secret.
+                    description: AdminPassword key to talk to the external grafana
+                      instance.
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -8133,7 +8144,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   adminUser:
-                    description: SecretKeySelector selects a key of a Secret.
+                    description: AdminUser key to talk to the external grafana instance.
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -8152,7 +8163,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   apiKey:
-                    description: SecretKeySelector selects a key of a Secret.
+                    description: The API key to talk to the external grafana instance,
+                      you need to define ether apiKey or adminUser/adminPassword.
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -8171,11 +8183,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   url:
+                    description: URL of the external grafana instance you want to
+                      manage.
                     type: string
                 required:
                 - url
                 type: object
               ingress:
+                description: Ingress sets how the ingress object should look like
+                  with your grafana instance.
                 properties:
                   metadata:
                     description: ObjectMeta contains only a [subset of the fields
@@ -8524,6 +8540,8 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               persistentVolumeClaim:
+                description: PersistentVolumeClaim creates a PVC if you need to attach
+                  one to your grafana instance.
                 properties:
                   metadata:
                     description: ObjectMeta contains only a [subset of the fields
@@ -8678,6 +8696,8 @@ spec:
                     type: object
                 type: object
               route:
+                description: Route sets how the ingress object should look like with
+                  your grafana instance, this only works in Openshift.
                 properties:
                   metadata:
                     description: ObjectMeta contains only a [subset of the fields
@@ -8814,6 +8834,8 @@ spec:
                     type: object
                 type: object
               service:
+                description: Service sets how the service object should look like
+                  with your grafana instance, contains a number of defaults.
                 properties:
                   metadata:
                     description: ObjectMeta contains only a [subset of the fields
@@ -9163,6 +9185,8 @@ spec:
                     type: object
                 type: object
               serviceAccount:
+                description: ServiceAccount sets how the ServiceAccount object should
+                  look like with your grafana instance, contains a number of defaults.
                 properties:
                   automountServiceAccountToken:
                     type: boolean

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,0 +1,9 @@
+# This kustomization.yaml is not intended to be run by itself,
+# It's only mean for documentation generation.
+# If you want to install the operator CRD us `make install` and it will use the files under crd/base
+resources:
+  - grafana.integreatly.org_grafanas.yaml
+  - grafana.integreatly.org_grafanadashboards.yaml
+  - grafana.integreatly.org_grafanadatasources.yaml
+  - grafana.integreatly.org_grafanafolders.yaml
+#+kubebuilder:scaffold:crdkustomizeresource

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -30,7 +30,7 @@ Resource Types:
 
 
 
-
+GrafanaDashboard is the Schema for the grafanadashboards API
 
 <table>
     <thead>
@@ -62,14 +62,14 @@ Resource Types:
         <td><b><a href="grafanadashboardspec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaDashboardSpec defines the desired state of GrafanaDashboard<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanadashboardstatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaDashboardStatus defines the observed state of GrafanaDashboard<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -81,7 +81,7 @@ Resource Types:
 
 
 
-
+GrafanaDashboardSpec defines the desired state of GrafanaDashboard
 
 <table>
     <thead>
@@ -96,42 +96,42 @@ Resource Types:
         <td><b><a href="grafanadashboardspecinstanceselector">instanceSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          selects Grafanas for import<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>allowCrossNamespaceImport</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          allow to import this resources from an operator in a different namespace<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>contentCacheDuration</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Cache duration for dashboards fetched from URLs<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanadashboardspecdatasourcesindex">datasources</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          maps required data sources to existing ones<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>folder</b></td>
         <td>string</td>
         <td>
-          <br/>
+          folder assignment for dashboard<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>gzipJson</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GzipJson the dashboard's JSON compressed with Gzip. Base64-encoded when in YAML.<br/>
           <br/>
             <i>Format</i>: byte<br/>
         </td>
@@ -140,35 +140,35 @@ Resource Types:
         <td><b>json</b></td>
         <td>string</td>
         <td>
-          <br/>
+          dashboard json<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>jsonnet</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Jsonnet<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanadashboardspecpluginsindex">plugins</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          plugins<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>resyncPeriod</b></td>
         <td>string</td>
         <td>
-          <br/>
+          how often the dashboard is refreshed, defaults to 24h if not set<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>url</b></td>
         <td>string</td>
         <td>
-          <br/>
+          dashboard url<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -180,7 +180,7 @@ Resource Types:
 
 
 
-
+selects Grafanas for import
 
 <table>
     <thead>
@@ -195,14 +195,14 @@ Resource Types:
         <td><b><a href="grafanadashboardspecinstanceselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -214,7 +214,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -229,21 +229,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -323,7 +323,7 @@ Resource Types:
 
 
 
-
+GrafanaDashboardStatus defines the observed state of GrafanaDashboard
 
 <table>
     <thead>
@@ -338,7 +338,7 @@ Resource Types:
         <td><b>NoMatchingInstances</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          The dashboard instanceSelector can't find matching grafana instances<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -384,7 +384,7 @@ Resource Types:
 
 
 
-
+GrafanaDatasource is the Schema for the grafanadatasources API
 
 <table>
     <thead>
@@ -416,14 +416,14 @@ Resource Types:
         <td><b><a href="grafanadatasourcespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaDatasourceSpec defines the desired state of GrafanaDatasource<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanadatasourcestatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaDatasourceStatus defines the observed state of GrafanaDatasource<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -435,7 +435,7 @@ Resource Types:
 
 
 
-
+GrafanaDatasourceSpec defines the desired state of GrafanaDatasource
 
 <table>
     <thead>
@@ -450,14 +450,14 @@ Resource Types:
         <td><b><a href="grafanadatasourcespecinstanceselector">instanceSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          selects Grafana instances for import<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>allowCrossNamespaceImport</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          allow to import this resources from an operator in a different namespace<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -471,21 +471,21 @@ Resource Types:
         <td><b><a href="grafanadatasourcespecpluginsindex">plugins</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          plugins<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>resyncPeriod</b></td>
         <td>string</td>
         <td>
-          <br/>
+          how often the datasource is refreshed, defaults to 24h if not set<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>secrets</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          secrets used for variable expansion<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -497,7 +497,7 @@ Resource Types:
 
 
 
-
+selects Grafana instances for import
 
 <table>
     <thead>
@@ -512,14 +512,14 @@ Resource Types:
         <td><b><a href="grafanadatasourcespecinstanceselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -531,7 +531,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -546,21 +546,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -726,7 +726,7 @@ Resource Types:
 
 
 
-
+GrafanaDatasourceStatus defines the observed state of GrafanaDatasource
 
 <table>
     <thead>
@@ -741,7 +741,7 @@ Resource Types:
         <td><b>NoMatchingInstances</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          The datasource instanceSelector can't find matching grafana instances<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -769,7 +769,7 @@ Resource Types:
 
 
 
-
+GrafanaFolder is the Schema for the grafanafolders API
 
 <table>
     <thead>
@@ -801,14 +801,14 @@ Resource Types:
         <td><b><a href="grafanafolderspec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaFolderSpec defines the desired state of GrafanaFolder<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanafolderstatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaFolderStatus defines the observed state of GrafanaFolder<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -820,7 +820,7 @@ Resource Types:
 
 
 
-
+GrafanaFolderSpec defines the desired state of GrafanaFolder
 
 <table>
     <thead>
@@ -835,14 +835,14 @@ Resource Types:
         <td><b><a href="grafanafolderspecinstanceselector">instanceSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          selects Grafanas for import<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>allowCrossNamespaceImport</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          allow to import this resources from an operator in a different namespace<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -861,7 +861,7 @@ Resource Types:
 
 
 
-
+selects Grafanas for import
 
 <table>
     <thead>
@@ -876,14 +876,14 @@ Resource Types:
         <td><b><a href="grafanafolderspecinstanceselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -895,7 +895,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -910,21 +910,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -936,7 +936,7 @@ Resource Types:
 
 
 
-
+GrafanaFolderStatus defines the observed state of GrafanaFolder
 
 <table>
     <thead>
@@ -951,14 +951,14 @@ Resource Types:
         <td><b>NoMatchingInstances</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          The folder instanceSelector can't find matching grafana instances<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hash</b></td>
         <td>string</td>
         <td>
-          <br/>
+          INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -972,7 +972,7 @@ Resource Types:
 
 
 
-
+Grafana is the Schema for the grafanas API
 
 <table>
     <thead>
@@ -1004,14 +1004,14 @@ Resource Types:
         <td><b><a href="grafanaspec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaSpec defines the desired state of Grafana<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanastatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GrafanaStatus defines the observed state of Grafana<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1023,7 +1023,7 @@ Resource Types:
 
 
 
-
+GrafanaSpec defines the desired state of Grafana
 
 <table>
     <thead>
@@ -1038,35 +1038,35 @@ Resource Types:
         <td><b><a href="grafanaspecclient">client</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Client defines how the grafana-operator talks to the grafana instance.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>config</b></td>
         <td>map[string]map[string]string</td>
         <td>
-          <br/>
+          Config defines how your grafana ini file should looks like.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeployment">deployment</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Deployment sets how the deployment object should look like with your grafana instance, contains a number of defaults.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecexternal">external</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          External enables you to configure external grafana instances that is not managed by the operator.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecingress">ingress</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Ingress sets how the ingress object should look like with your grafana instance.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1080,28 +1080,28 @@ Resource Types:
         <td><b><a href="grafanaspecpersistentvolumeclaim">persistentVolumeClaim</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PersistentVolumeClaim creates a PVC if you need to attach one to your grafana instance.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecroute">route</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Route sets how the ingress object should look like with your grafana instance, this only works in Openshift.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecservice">service</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Service sets how the service object should look like with your grafana instance, contains a number of defaults.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecserviceaccount">serviceAccount</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ServiceAccount sets how the ServiceAccount object should look like with your grafana instance, contains a number of defaults.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1113,7 +1113,7 @@ Resource Types:
 
 
 
-
+Client defines how the grafana-operator talks to the grafana instance.
 
 <table>
     <thead>
@@ -1128,7 +1128,7 @@ Resource Types:
         <td><b>preferIngress</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          If the operator should send it's request through the grafana instances ingress object instead of through the service.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1147,7 +1147,7 @@ Resource Types:
 
 
 
-
+Deployment sets how the deployment object should look like with your grafana instance, contains a number of defaults.
 
 <table>
     <thead>
@@ -1162,7 +1162,7 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentmetadata">metadata</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1181,7 +1181,7 @@ Resource Types:
 
 
 
-
+ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).
 
 <table>
     <thead>
@@ -1273,14 +1273,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspecselector">selector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspecstrategy">strategy</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          DeploymentStrategy describes how to replace existing pods with new ones.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1299,7 +1299,7 @@ Resource Types:
 
 
 
-
+A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
 
 <table>
     <thead>
@@ -1314,14 +1314,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspecselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1333,7 +1333,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -1348,21 +1348,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1374,7 +1374,7 @@ Resource Types:
 
 
 
-
+DeploymentStrategy describes how to replace existing pods with new ones.
 
 <table>
     <thead>
@@ -1389,14 +1389,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspecstrategyrollingupdate">rollingUpdate</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1408,7 +1408,7 @@ Resource Types:
 
 
 
-
+Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.
 
 <table>
     <thead>
@@ -1423,14 +1423,14 @@ Resource Types:
         <td><b>maxSurge</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>maxUnavailable</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1457,14 +1457,14 @@ Resource Types:
         <td><b>metadata</b></td>
         <td>object</td>
         <td>
-          <br/>
+          Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1476,7 +1476,7 @@ Resource Types:
 
 
 
-
+Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 <table>
     <thead>
@@ -1500,14 +1500,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinity">affinity</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          If specified, the pod's scheduling constraints<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>automountServiceAccountToken</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1521,21 +1521,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecdnsconfig">dnsConfig</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>dnsPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          DNSPolicy defines how a pod's DNS will be configured.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>enableServiceLinks</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1549,49 +1549,49 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespechostaliasesindex">hostAliases</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostIPC</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Use the host's ipc namespace. Optional: Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostNetwork</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostPID</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Use the host's pid namespace. Optional: Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostUsers</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostname</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecimagepullsecretsindex">imagePullSecrets</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1605,42 +1605,44 @@ Resource Types:
         <td><b>nodeName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>nodeSelector</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecos">os</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. 
+ If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions 
+ If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>overhead</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>preemptionPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>priority</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -1649,77 +1651,77 @@ Resource Types:
         <td><b>priorityClassName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecreadinessgatesindex">readinessGates</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          RestartPolicy describes how the container should be restarted. Only one of the following restart policies may be specified. If none of the following policies is specified, the default one is RestartPolicyAlways.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runtimeClassName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>schedulerName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>serviceAccount</b></td>
         <td>string</td>
         <td>
-          <br/>
+          DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>serviceAccountName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>setHostnameAsFQDN</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>shareProcessNamespace</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subdomain</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1735,14 +1737,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespectolerationsindex">tolerations</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          If specified, the pod's tolerations.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespectopologyspreadconstraintsindex">topologySpreadConstraints</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1761,7 +1763,7 @@ Resource Types:
 
 
 
-
+If specified, the pod's scheduling constraints
 
 <table>
     <thead>
@@ -1776,21 +1778,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinity">nodeAffinity</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Describes node affinity scheduling rules for the pod.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinity">podAffinity</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinity">podAntiAffinity</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1802,7 +1804,7 @@ Resource Types:
 
 
 
-
+Describes node affinity scheduling rules for the pod.
 
 <table>
     <thead>
@@ -1817,14 +1819,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinitypreferredduringschedulingignoredduringexecutionindex">preferredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinityrequiredduringschedulingignoredduringexecution">requiredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1836,7 +1838,7 @@ Resource Types:
 
 
 
-
+An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
 
 <table>
     <thead>
@@ -1851,14 +1853,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinitypreferredduringschedulingignoredduringexecutionindexpreference">preference</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A node selector term, associated with the corresponding weight.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -1872,7 +1874,7 @@ Resource Types:
 
 
 
-
+A node selector term, associated with the corresponding weight.
 
 <table>
     <thead>
@@ -1887,14 +1889,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinitypreferredduringschedulingignoredduringexecutionindexpreferencematchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          A list of node selector requirements by node's labels.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinitypreferredduringschedulingignoredduringexecutionindexpreferencematchfieldsindex">matchFields</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          A list of node selector requirements by node's fields.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1906,7 +1908,7 @@ Resource Types:
 
 
 
-
+A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -1921,21 +1923,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1947,7 +1949,7 @@ Resource Types:
 
 
 
-
+A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -1962,21 +1964,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1988,7 +1990,7 @@ Resource Types:
 
 
 
-
+If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
 
 <table>
     <thead>
@@ -2003,7 +2005,7 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinityrequiredduringschedulingignoredduringexecutionnodeselectortermsindex">nodeSelectorTerms</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Required. A list of node selector terms. The terms are ORed.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -2015,7 +2017,7 @@ Resource Types:
 
 
 
-
+A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
 
 <table>
     <thead>
@@ -2030,14 +2032,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinityrequiredduringschedulingignoredduringexecutionnodeselectortermsindexmatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          A list of node selector requirements by node's labels.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitynodeaffinityrequiredduringschedulingignoredduringexecutionnodeselectortermsindexmatchfieldsindex">matchFields</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          A list of node selector requirements by node's fields.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2049,7 +2051,7 @@ Resource Types:
 
 
 
-
+A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2064,21 +2066,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2090,7 +2092,7 @@ Resource Types:
 
 
 
-
+A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2105,21 +2107,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2131,7 +2133,7 @@ Resource Types:
 
 
 
-
+Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
 
 <table>
     <thead>
@@ -2146,14 +2148,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindex">preferredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindex">requiredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2165,7 +2167,7 @@ Resource Types:
 
 
 
-
+The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
 
 <table>
     <thead>
@@ -2180,14 +2182,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinityterm">podAffinityTerm</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Required. A pod affinity term, associated with the corresponding weight.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          weight associated with matching the corresponding podAffinityTerm, in the range 1-100.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -2201,7 +2203,7 @@ Resource Types:
 
 
 
-
+Required. A pod affinity term, associated with the corresponding weight.
 
 <table>
     <thead>
@@ -2216,28 +2218,28 @@ Resource Types:
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          <br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over a set of resources, in this case pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2249,7 +2251,7 @@ Resource Types:
 
 
 
-
+A label query over a set of resources, in this case pods.
 
 <table>
     <thead>
@@ -2264,14 +2266,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermlabelselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2283,7 +2285,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2298,21 +2300,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2324,7 +2326,7 @@ Resource Types:
 
 
 
-
+A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -2339,14 +2341,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermnamespaceselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2358,7 +2360,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2373,21 +2375,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2399,7 +2401,7 @@ Resource Types:
 
 
 
-
+Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
 
 <table>
     <thead>
@@ -2414,28 +2416,28 @@ Resource Types:
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          <br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindexlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over a set of resources, in this case pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindexnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2447,7 +2449,7 @@ Resource Types:
 
 
 
-
+A label query over a set of resources, in this case pods.
 
 <table>
     <thead>
@@ -2462,14 +2464,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindexlabelselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2481,7 +2483,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2496,21 +2498,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2522,7 +2524,7 @@ Resource Types:
 
 
 
-
+A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -2537,14 +2539,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindexnamespaceselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2556,7 +2558,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2571,21 +2573,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2597,7 +2599,7 @@ Resource Types:
 
 
 
-
+Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
 
 <table>
     <thead>
@@ -2612,14 +2614,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindex">preferredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindex">requiredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2631,7 +2633,7 @@ Resource Types:
 
 
 
-
+The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
 
 <table>
     <thead>
@@ -2646,14 +2648,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinityterm">podAffinityTerm</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Required. A pod affinity term, associated with the corresponding weight.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          weight associated with matching the corresponding podAffinityTerm, in the range 1-100.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -2667,7 +2669,7 @@ Resource Types:
 
 
 
-
+Required. A pod affinity term, associated with the corresponding weight.
 
 <table>
     <thead>
@@ -2682,28 +2684,28 @@ Resource Types:
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          <br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over a set of resources, in this case pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2715,7 +2717,7 @@ Resource Types:
 
 
 
-
+A label query over a set of resources, in this case pods.
 
 <table>
     <thead>
@@ -2730,14 +2732,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermlabelselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2749,7 +2751,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2764,21 +2766,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2790,7 +2792,7 @@ Resource Types:
 
 
 
-
+A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -2805,14 +2807,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermnamespaceselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2824,7 +2826,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2839,21 +2841,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2865,7 +2867,7 @@ Resource Types:
 
 
 
-
+Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
 
 <table>
     <thead>
@@ -2880,28 +2882,28 @@ Resource Types:
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          <br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindexlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over a set of resources, in this case pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindexnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2913,7 +2915,7 @@ Resource Types:
 
 
 
-
+A label query over a set of resources, in this case pods.
 
 <table>
     <thead>
@@ -2928,14 +2930,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindexlabelselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2947,7 +2949,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -2962,21 +2964,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2988,7 +2990,7 @@ Resource Types:
 
 
 
-
+A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -3003,14 +3005,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindexnamespaceselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3022,7 +3024,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -3037,21 +3039,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3063,7 +3065,7 @@ Resource Types:
 
 
 
-
+A single application container that you want to run within a pod.
 
 <table>
     <thead>
@@ -3078,154 +3080,154 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvindex">env</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of environment variables to set in the container. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvfromindex">envFrom</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecycle">lifecycle</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Actions that the management system should take in response to container lifecycle events. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlivenessprobe">livenessProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexportsindex">ports</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexreadinessprobe">readinessProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexresources">resources</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexstartupprobe">startupProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdin</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdinOnce</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tty</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexvolumedevicesindex">volumeDevices</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          volumeDevices is the list of block devices to be used by the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexvolumemountsindex">volumeMounts</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Pod volumes to mount into the container's filesystem. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>workingDir</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3237,7 +3239,7 @@ Resource Types:
 
 
 
-
+EnvVar represents an environment variable present in a Container.
 
 <table>
     <thead>
@@ -3252,21 +3254,21 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the environment variable. Must be a C_IDENTIFIER.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvindexvaluefrom">valueFrom</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Source for the environment variable's value. Cannot be used if value is not empty.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3278,7 +3280,7 @@ Resource Types:
 
 
 
-
+Source for the environment variable's value. Cannot be used if value is not empty.
 
 <table>
     <thead>
@@ -3293,28 +3295,28 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvindexvaluefromconfigmapkeyref">configMapKeyRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a key of a ConfigMap.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvindexvaluefromfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvindexvaluefromresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvindexvaluefromsecretkeyref">secretKeyRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a key of a secret in the pod's namespace<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3326,7 +3328,7 @@ Resource Types:
 
 
 
-
+Selects a key of a ConfigMap.
 
 <table>
     <thead>
@@ -3341,21 +3343,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key to select.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the ConfigMap or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3367,7 +3369,7 @@ Resource Types:
 
 
 
-
+Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 
 <table>
     <thead>
@@ -3382,14 +3384,14 @@ Resource Types:
         <td><b>fieldPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path of the field to select in the specified API version.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiVersion</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Version of the schema the FieldPath is written in terms of, defaults to "v1".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3401,7 +3403,7 @@ Resource Types:
 
 
 
-
+Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
 
 <table>
     <thead>
@@ -3416,21 +3418,21 @@ Resource Types:
         <td><b>resource</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required: resource to select<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>containerName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container name: required for volumes, optional for env vars<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>divisor</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Specifies the output format of the exposed resources, defaults to "1"<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3442,7 +3444,7 @@ Resource Types:
 
 
 
-
+Selects a key of a secret in the pod's namespace
 
 <table>
     <thead>
@@ -3457,21 +3459,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key of the secret to select from.  Must be a valid secret key.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3483,7 +3485,7 @@ Resource Types:
 
 
 
-
+EnvFromSource represents the source of a set of ConfigMaps
 
 <table>
     <thead>
@@ -3498,21 +3500,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvfromindexconfigmapref">configMapRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The ConfigMap to select from<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>prefix</b></td>
         <td>string</td>
         <td>
-          <br/>
+          An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexenvfromindexsecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The Secret to select from<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3524,7 +3526,7 @@ Resource Types:
 
 
 
-
+The ConfigMap to select from
 
 <table>
     <thead>
@@ -3539,14 +3541,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the ConfigMap must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3558,7 +3560,7 @@ Resource Types:
 
 
 
-
+The Secret to select from
 
 <table>
     <thead>
@@ -3573,14 +3575,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3592,7 +3594,7 @@ Resource Types:
 
 
 
-
+Actions that the management system should take in response to container lifecycle events. Cannot be updated.
 
 <table>
     <thead>
@@ -3607,14 +3609,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecyclepoststart">postStart</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecycleprestop">preStop</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3626,7 +3628,7 @@ Resource Types:
 
 
 
-
+PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -3641,21 +3643,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecyclepoststartexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecyclepoststarthttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecyclepoststarttcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3667,7 +3669,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -3682,7 +3684,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3694,7 +3696,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -3709,35 +3711,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecyclepoststarthttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3749,7 +3751,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -3764,14 +3766,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -3783,7 +3785,7 @@ Resource Types:
 
 
 
-
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -3798,14 +3800,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3817,7 +3819,7 @@ Resource Types:
 
 
 
-
+PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -3832,21 +3834,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecycleprestopexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecycleprestophttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecycleprestoptcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3858,7 +3860,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -3873,7 +3875,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3885,7 +3887,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -3900,35 +3902,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlifecycleprestophttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3940,7 +3942,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -3955,14 +3957,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -3974,7 +3976,7 @@ Resource Types:
 
 
 
-
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -3989,14 +3991,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4008,7 +4010,7 @@ Resource Types:
 
 
 
-
+Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -4023,14 +4025,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlivenessprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4039,21 +4041,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlivenessprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlivenessprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4062,7 +4064,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4071,7 +4073,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4080,14 +4082,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlivenessprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -4096,7 +4098,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4110,7 +4112,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -4125,7 +4127,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4137,7 +4139,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -4152,7 +4154,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4161,7 +4163,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4173,7 +4176,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -4188,35 +4191,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexlivenessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4228,7 +4231,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -4243,14 +4246,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -4262,7 +4265,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -4277,14 +4280,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4296,7 +4299,7 @@ Resource Types:
 
 
 
-
+ContainerPort represents a network port in a single container.
 
 <table>
     <thead>
@@ -4311,7 +4314,7 @@ Resource Types:
         <td><b>containerPort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4320,14 +4323,14 @@ Resource Types:
         <td><b>hostIP</b></td>
         <td>string</td>
         <td>
-          <br/>
+          What host IP to bind the external port to.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostPort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4336,14 +4339,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -4357,7 +4360,7 @@ Resource Types:
 
 
 
-
+Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -4372,14 +4375,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexreadinessprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4388,21 +4391,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexreadinessprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexreadinessprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4411,7 +4414,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4420,7 +4423,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4429,14 +4432,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexreadinessprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -4445,7 +4448,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4459,7 +4462,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -4474,7 +4477,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4486,7 +4489,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -4501,7 +4504,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4510,7 +4513,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4522,7 +4526,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -4537,35 +4541,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexreadinessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4577,7 +4581,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -4592,14 +4596,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -4611,7 +4615,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -4626,14 +4630,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4645,7 +4649,7 @@ Resource Types:
 
 
 
-
+Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 <table>
     <thead>
@@ -4660,14 +4664,14 @@ Resource Types:
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4679,7 +4683,7 @@ Resource Types:
 
 
 
-
+SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
 <table>
     <thead>
@@ -4694,42 +4698,42 @@ Resource Types:
         <td><b>allowPrivilegeEscalation</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextcapabilities">capabilities</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>procMount</b></td>
         <td>string</td>
         <td>
-          <br/>
+          procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnlyRootFilesystem</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -4738,14 +4742,14 @@ Resource Types:
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -4754,21 +4758,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4780,7 +4784,7 @@ Resource Types:
 
 
 
-
+The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -4795,14 +4799,14 @@ Resource Types:
         <td><b>add</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Added capabilities<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>drop</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Removed capabilities<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4814,7 +4818,7 @@ Resource Types:
 
 
 
-
+The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -4829,28 +4833,28 @@ Resource Types:
         <td><b>level</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Level is SELinux level label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>role</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Role is a SELinux role label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Type is a SELinux type label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          <br/>
+          User is a SELinux user label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4862,7 +4866,7 @@ Resource Types:
 
 
 
-
+The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -4877,14 +4881,15 @@ Resource Types:
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          type indicates which kind of seccomp profile will be applied. Valid options are: 
+ Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          <br/>
+          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4896,7 +4901,7 @@ Resource Types:
 
 
 
-
+The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -4911,28 +4916,28 @@ Resource Types:
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>gmsaCredentialSpecName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpecName is the name of the GMSA credential spec to use.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4944,7 +4949,7 @@ Resource Types:
 
 
 
-
+StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -4959,14 +4964,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexstartupprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4975,21 +4980,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexstartupprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexstartupprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -4998,7 +5003,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5007,7 +5012,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5016,14 +5021,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexstartupprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -5032,7 +5037,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5046,7 +5051,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -5061,7 +5066,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5073,7 +5078,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -5088,7 +5093,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5097,7 +5102,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5109,7 +5115,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -5124,35 +5130,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespeccontainersindexstartupprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5164,7 +5170,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -5179,14 +5185,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -5198,7 +5204,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -5213,14 +5219,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5232,7 +5238,7 @@ Resource Types:
 
 
 
-
+volumeDevice describes a mapping of a raw block device within a container.
 
 <table>
     <thead>
@@ -5247,14 +5253,14 @@ Resource Types:
         <td><b>devicePath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          devicePath is the path inside of the container that the device will be mapped to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          name must match the name of a persistentVolumeClaim in the pod<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -5266,7 +5272,7 @@ Resource Types:
 
 
 
-
+VolumeMount describes a mounting of a Volume within a container.
 
 <table>
     <thead>
@@ -5281,42 +5287,42 @@ Resource Types:
         <td><b>mountPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path within the container at which the volume should be mounted.  Must not contain ':'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          This must match the Name of a Volume.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mountPropagation</b></td>
         <td>string</td>
         <td>
-          <br/>
+          mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPathExpr</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5328,7 +5334,7 @@ Resource Types:
 
 
 
-
+Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
 
 <table>
     <thead>
@@ -5343,21 +5349,21 @@ Resource Types:
         <td><b>nameservers</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecdnsconfigoptionsindex">options</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>searches</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5369,7 +5375,7 @@ Resource Types:
 
 
 
-
+PodDNSConfigOption defines DNS resolver options of a pod.
 
 <table>
     <thead>
@@ -5384,7 +5390,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5403,7 +5409,8 @@ Resource Types:
 
 
 
-
+An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. 
+ To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
 
 <table>
     <thead>
@@ -5418,161 +5425,162 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindex">env</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of environment variables to set in the container. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvfromindex">envFrom</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container image name. More info: https://kubernetes.io/docs/concepts/containers/images<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycle">lifecycle</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Lifecycle is not allowed for ephemeral containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlivenessprobe">livenessProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Probes are not allowed for ephemeral containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexportsindex">ports</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Ports are not allowed for ephemeral containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexreadinessprobe">readinessProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Probes are not allowed for ephemeral containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexresources">resources</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexstartupprobe">startupProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Probes are not allowed for ephemeral containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdin</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdinOnce</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>targetContainerName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec. 
+ The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tty</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexvolumedevicesindex">volumeDevices</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          volumeDevices is the list of block devices to be used by the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexvolumemountsindex">volumeMounts</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>workingDir</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5584,7 +5592,7 @@ Resource Types:
 
 
 
-
+EnvVar represents an environment variable present in a Container.
 
 <table>
     <thead>
@@ -5599,21 +5607,21 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the environment variable. Must be a C_IDENTIFIER.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindexvaluefrom">valueFrom</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Source for the environment variable's value. Cannot be used if value is not empty.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5625,7 +5633,7 @@ Resource Types:
 
 
 
-
+Source for the environment variable's value. Cannot be used if value is not empty.
 
 <table>
     <thead>
@@ -5640,28 +5648,28 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindexvaluefromconfigmapkeyref">configMapKeyRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a key of a ConfigMap.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindexvaluefromfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindexvaluefromresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindexvaluefromsecretkeyref">secretKeyRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a key of a secret in the pod's namespace<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5673,7 +5681,7 @@ Resource Types:
 
 
 
-
+Selects a key of a ConfigMap.
 
 <table>
     <thead>
@@ -5688,21 +5696,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key to select.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the ConfigMap or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5714,7 +5722,7 @@ Resource Types:
 
 
 
-
+Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 
 <table>
     <thead>
@@ -5729,14 +5737,14 @@ Resource Types:
         <td><b>fieldPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path of the field to select in the specified API version.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiVersion</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Version of the schema the FieldPath is written in terms of, defaults to "v1".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5748,7 +5756,7 @@ Resource Types:
 
 
 
-
+Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
 
 <table>
     <thead>
@@ -5763,21 +5771,21 @@ Resource Types:
         <td><b>resource</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required: resource to select<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>containerName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container name: required for volumes, optional for env vars<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>divisor</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Specifies the output format of the exposed resources, defaults to "1"<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5789,7 +5797,7 @@ Resource Types:
 
 
 
-
+Selects a key of a secret in the pod's namespace
 
 <table>
     <thead>
@@ -5804,21 +5812,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key of the secret to select from.  Must be a valid secret key.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5830,7 +5838,7 @@ Resource Types:
 
 
 
-
+EnvFromSource represents the source of a set of ConfigMaps
 
 <table>
     <thead>
@@ -5845,21 +5853,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvfromindexconfigmapref">configMapRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The ConfigMap to select from<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>prefix</b></td>
         <td>string</td>
         <td>
-          <br/>
+          An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvfromindexsecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The Secret to select from<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5871,7 +5879,7 @@ Resource Types:
 
 
 
-
+The ConfigMap to select from
 
 <table>
     <thead>
@@ -5886,14 +5894,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the ConfigMap must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5905,7 +5913,7 @@ Resource Types:
 
 
 
-
+The Secret to select from
 
 <table>
     <thead>
@@ -5920,14 +5928,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5939,7 +5947,7 @@ Resource Types:
 
 
 
-
+Lifecycle is not allowed for ephemeral containers.
 
 <table>
     <thead>
@@ -5954,14 +5962,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecyclepoststart">postStart</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycleprestop">preStop</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5973,7 +5981,7 @@ Resource Types:
 
 
 
-
+PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -5988,21 +5996,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecyclepoststartexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecyclepoststarthttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecyclepoststarttcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6014,7 +6022,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -6029,7 +6037,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6041,7 +6049,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -6056,35 +6064,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecyclepoststarthttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6096,7 +6104,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -6111,14 +6119,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -6130,7 +6138,7 @@ Resource Types:
 
 
 
-
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -6145,14 +6153,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6164,7 +6172,7 @@ Resource Types:
 
 
 
-
+PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -6179,21 +6187,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycleprestopexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycleprestophttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycleprestoptcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6205,7 +6213,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -6220,7 +6228,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6232,7 +6240,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -6247,35 +6255,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycleprestophttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6287,7 +6295,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -6302,14 +6310,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -6321,7 +6329,7 @@ Resource Types:
 
 
 
-
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -6336,14 +6344,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6355,7 +6363,7 @@ Resource Types:
 
 
 
-
+Probes are not allowed for ephemeral containers.
 
 <table>
     <thead>
@@ -6370,14 +6378,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlivenessprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6386,21 +6394,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlivenessprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlivenessprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6409,7 +6417,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6418,7 +6426,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6427,14 +6435,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlivenessprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -6443,7 +6451,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6457,7 +6465,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -6472,7 +6480,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6484,7 +6492,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -6499,7 +6507,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6508,7 +6516,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6520,7 +6529,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -6535,35 +6544,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexlivenessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6575,7 +6584,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -6590,14 +6599,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -6609,7 +6618,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -6624,14 +6633,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6643,7 +6652,7 @@ Resource Types:
 
 
 
-
+ContainerPort represents a network port in a single container.
 
 <table>
     <thead>
@@ -6658,7 +6667,7 @@ Resource Types:
         <td><b>containerPort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6667,14 +6676,14 @@ Resource Types:
         <td><b>hostIP</b></td>
         <td>string</td>
         <td>
-          <br/>
+          What host IP to bind the external port to.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostPort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6683,14 +6692,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -6704,7 +6713,7 @@ Resource Types:
 
 
 
-
+Probes are not allowed for ephemeral containers.
 
 <table>
     <thead>
@@ -6719,14 +6728,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexreadinessprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6735,21 +6744,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexreadinessprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexreadinessprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6758,7 +6767,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6767,7 +6776,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6776,14 +6785,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexreadinessprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -6792,7 +6801,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6806,7 +6815,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -6821,7 +6830,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6833,7 +6842,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -6848,7 +6857,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6857,7 +6866,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6869,7 +6879,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -6884,35 +6894,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexreadinessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6924,7 +6934,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -6939,14 +6949,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -6958,7 +6968,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -6973,14 +6983,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6992,7 +7002,7 @@ Resource Types:
 
 
 
-
+Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
 
 <table>
     <thead>
@@ -7007,14 +7017,14 @@ Resource Types:
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7026,7 +7036,7 @@ Resource Types:
 
 
 
-
+Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 
 <table>
     <thead>
@@ -7041,42 +7051,42 @@ Resource Types:
         <td><b>allowPrivilegeEscalation</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextcapabilities">capabilities</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>procMount</b></td>
         <td>string</td>
         <td>
-          <br/>
+          procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnlyRootFilesystem</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -7085,14 +7095,14 @@ Resource Types:
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -7101,21 +7111,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7127,7 +7137,7 @@ Resource Types:
 
 
 
-
+The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -7142,14 +7152,14 @@ Resource Types:
         <td><b>add</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Added capabilities<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>drop</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Removed capabilities<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7161,7 +7171,7 @@ Resource Types:
 
 
 
-
+The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -7176,28 +7186,28 @@ Resource Types:
         <td><b>level</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Level is SELinux level label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>role</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Role is a SELinux role label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Type is a SELinux type label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          <br/>
+          User is a SELinux user label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7209,7 +7219,7 @@ Resource Types:
 
 
 
-
+The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -7224,14 +7234,15 @@ Resource Types:
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          type indicates which kind of seccomp profile will be applied. Valid options are: 
+ Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          <br/>
+          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7243,7 +7254,7 @@ Resource Types:
 
 
 
-
+The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -7258,28 +7269,28 @@ Resource Types:
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>gmsaCredentialSpecName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpecName is the name of the GMSA credential spec to use.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7291,7 +7302,7 @@ Resource Types:
 
 
 
-
+Probes are not allowed for ephemeral containers.
 
 <table>
     <thead>
@@ -7306,14 +7317,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexstartupprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7322,21 +7333,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexstartupprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexstartupprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7345,7 +7356,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7354,7 +7365,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7363,14 +7374,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexstartupprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -7379,7 +7390,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7393,7 +7404,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -7408,7 +7419,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7420,7 +7431,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -7435,7 +7446,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7444,7 +7455,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7456,7 +7468,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -7471,35 +7483,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecephemeralcontainersindexstartupprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7511,7 +7523,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -7526,14 +7538,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -7545,7 +7557,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -7560,14 +7572,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7579,7 +7591,7 @@ Resource Types:
 
 
 
-
+volumeDevice describes a mapping of a raw block device within a container.
 
 <table>
     <thead>
@@ -7594,14 +7606,14 @@ Resource Types:
         <td><b>devicePath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          devicePath is the path inside of the container that the device will be mapped to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          name must match the name of a persistentVolumeClaim in the pod<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -7613,7 +7625,7 @@ Resource Types:
 
 
 
-
+VolumeMount describes a mounting of a Volume within a container.
 
 <table>
     <thead>
@@ -7628,42 +7640,42 @@ Resource Types:
         <td><b>mountPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path within the container at which the volume should be mounted.  Must not contain ':'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          This must match the Name of a Volume.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mountPropagation</b></td>
         <td>string</td>
         <td>
-          <br/>
+          mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPathExpr</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7675,7 +7687,7 @@ Resource Types:
 
 
 
-
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 <table>
     <thead>
@@ -7690,14 +7702,14 @@ Resource Types:
         <td><b>hostnames</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Hostnames for the above IP address.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ip</b></td>
         <td>string</td>
         <td>
-          <br/>
+          IP address of the host file entry.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7709,7 +7721,7 @@ Resource Types:
 
 
 
-
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -7724,7 +7736,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7736,7 +7748,7 @@ Resource Types:
 
 
 
-
+A single application container that you want to run within a pod.
 
 <table>
     <thead>
@@ -7751,154 +7763,154 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvindex">env</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of environment variables to set in the container. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvfromindex">envFrom</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycle">lifecycle</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Actions that the management system should take in response to container lifecycle events. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlivenessprobe">livenessProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexportsindex">ports</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexreadinessprobe">readinessProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexresources">resources</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexstartupprobe">startupProbe</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdin</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdinOnce</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tty</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexvolumedevicesindex">volumeDevices</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          volumeDevices is the list of block devices to be used by the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexvolumemountsindex">volumeMounts</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Pod volumes to mount into the container's filesystem. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>workingDir</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7910,7 +7922,7 @@ Resource Types:
 
 
 
-
+EnvVar represents an environment variable present in a Container.
 
 <table>
     <thead>
@@ -7925,21 +7937,21 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the environment variable. Must be a C_IDENTIFIER.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvindexvaluefrom">valueFrom</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Source for the environment variable's value. Cannot be used if value is not empty.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7951,7 +7963,7 @@ Resource Types:
 
 
 
-
+Source for the environment variable's value. Cannot be used if value is not empty.
 
 <table>
     <thead>
@@ -7966,28 +7978,28 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvindexvaluefromconfigmapkeyref">configMapKeyRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a key of a ConfigMap.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvindexvaluefromfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvindexvaluefromresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvindexvaluefromsecretkeyref">secretKeyRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a key of a secret in the pod's namespace<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7999,7 +8011,7 @@ Resource Types:
 
 
 
-
+Selects a key of a ConfigMap.
 
 <table>
     <thead>
@@ -8014,21 +8026,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key to select.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the ConfigMap or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8040,7 +8052,7 @@ Resource Types:
 
 
 
-
+Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 
 <table>
     <thead>
@@ -8055,14 +8067,14 @@ Resource Types:
         <td><b>fieldPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path of the field to select in the specified API version.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiVersion</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Version of the schema the FieldPath is written in terms of, defaults to "v1".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8074,7 +8086,7 @@ Resource Types:
 
 
 
-
+Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
 
 <table>
     <thead>
@@ -8089,21 +8101,21 @@ Resource Types:
         <td><b>resource</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required: resource to select<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>containerName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container name: required for volumes, optional for env vars<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>divisor</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Specifies the output format of the exposed resources, defaults to "1"<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8115,7 +8127,7 @@ Resource Types:
 
 
 
-
+Selects a key of a secret in the pod's namespace
 
 <table>
     <thead>
@@ -8130,21 +8142,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key of the secret to select from.  Must be a valid secret key.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8156,7 +8168,7 @@ Resource Types:
 
 
 
-
+EnvFromSource represents the source of a set of ConfigMaps
 
 <table>
     <thead>
@@ -8171,21 +8183,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvfromindexconfigmapref">configMapRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The ConfigMap to select from<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>prefix</b></td>
         <td>string</td>
         <td>
-          <br/>
+          An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexenvfromindexsecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The Secret to select from<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8197,7 +8209,7 @@ Resource Types:
 
 
 
-
+The ConfigMap to select from
 
 <table>
     <thead>
@@ -8212,14 +8224,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the ConfigMap must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8231,7 +8243,7 @@ Resource Types:
 
 
 
-
+The Secret to select from
 
 <table>
     <thead>
@@ -8246,14 +8258,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8265,7 +8277,7 @@ Resource Types:
 
 
 
-
+Actions that the management system should take in response to container lifecycle events. Cannot be updated.
 
 <table>
     <thead>
@@ -8280,14 +8292,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecyclepoststart">postStart</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycleprestop">preStop</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8299,7 +8311,7 @@ Resource Types:
 
 
 
-
+PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -8314,21 +8326,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecyclepoststartexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecyclepoststarthttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecyclepoststarttcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8340,7 +8352,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -8355,7 +8367,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8367,7 +8379,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -8382,35 +8394,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecyclepoststarthttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8422,7 +8434,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -8437,14 +8449,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -8456,7 +8468,7 @@ Resource Types:
 
 
 
-
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -8471,14 +8483,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8490,7 +8502,7 @@ Resource Types:
 
 
 
-
+PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -8505,21 +8517,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycleprestopexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycleprestophttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycleprestoptcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8531,7 +8543,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -8546,7 +8558,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8558,7 +8570,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -8573,35 +8585,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycleprestophttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8613,7 +8625,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -8628,14 +8640,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -8647,7 +8659,7 @@ Resource Types:
 
 
 
-
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -8662,14 +8674,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8681,7 +8693,7 @@ Resource Types:
 
 
 
-
+Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -8696,14 +8708,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlivenessprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8712,21 +8724,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlivenessprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlivenessprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8735,7 +8747,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8744,7 +8756,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8753,14 +8765,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlivenessprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -8769,7 +8781,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8783,7 +8795,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -8798,7 +8810,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8810,7 +8822,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -8825,7 +8837,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8834,7 +8846,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8846,7 +8859,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -8861,35 +8874,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexlivenessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8901,7 +8914,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -8916,14 +8929,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -8935,7 +8948,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -8950,14 +8963,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8969,7 +8982,7 @@ Resource Types:
 
 
 
-
+ContainerPort represents a network port in a single container.
 
 <table>
     <thead>
@@ -8984,7 +8997,7 @@ Resource Types:
         <td><b>containerPort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8993,14 +9006,14 @@ Resource Types:
         <td><b>hostIP</b></td>
         <td>string</td>
         <td>
-          <br/>
+          What host IP to bind the external port to.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostPort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9009,14 +9022,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -9030,7 +9043,7 @@ Resource Types:
 
 
 
-
+Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -9045,14 +9058,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexreadinessprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9061,21 +9074,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexreadinessprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexreadinessprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9084,7 +9097,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9093,7 +9106,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9102,14 +9115,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexreadinessprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -9118,7 +9131,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9132,7 +9145,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -9147,7 +9160,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9159,7 +9172,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -9174,7 +9187,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9183,7 +9196,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9195,7 +9209,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -9210,35 +9224,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexreadinessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9250,7 +9264,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -9265,14 +9279,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -9284,7 +9298,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -9299,14 +9313,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9318,7 +9332,7 @@ Resource Types:
 
 
 
-
+Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 <table>
     <thead>
@@ -9333,14 +9347,14 @@ Resource Types:
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9352,7 +9366,7 @@ Resource Types:
 
 
 
-
+SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
 <table>
     <thead>
@@ -9367,42 +9381,42 @@ Resource Types:
         <td><b>allowPrivilegeEscalation</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextcapabilities">capabilities</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>procMount</b></td>
         <td>string</td>
         <td>
-          <br/>
+          procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnlyRootFilesystem</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -9411,14 +9425,14 @@ Resource Types:
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -9427,21 +9441,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9453,7 +9467,7 @@ Resource Types:
 
 
 
-
+The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -9468,14 +9482,14 @@ Resource Types:
         <td><b>add</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Added capabilities<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>drop</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Removed capabilities<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9487,7 +9501,7 @@ Resource Types:
 
 
 
-
+The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -9502,28 +9516,28 @@ Resource Types:
         <td><b>level</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Level is SELinux level label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>role</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Role is a SELinux role label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Type is a SELinux type label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          <br/>
+          User is a SELinux user label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9535,7 +9549,7 @@ Resource Types:
 
 
 
-
+The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -9550,14 +9564,15 @@ Resource Types:
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          type indicates which kind of seccomp profile will be applied. Valid options are: 
+ Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          <br/>
+          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9569,7 +9584,7 @@ Resource Types:
 
 
 
-
+The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -9584,28 +9599,28 @@ Resource Types:
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>gmsaCredentialSpecName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpecName is the name of the GMSA credential spec to use.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9617,7 +9632,7 @@ Resource Types:
 
 
 
-
+StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -9632,14 +9647,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexstartupprobeexec">exec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Exec specifies the action to take.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9648,21 +9663,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexstartupprobegrpc">grpc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexstartupprobehttpget">httpGet</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPGet specifies the http request to perform.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9671,7 +9686,7 @@ Resource Types:
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9680,7 +9695,7 @@ Resource Types:
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9689,14 +9704,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexstartupprobetcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TCPSocket specifies an action involving a TCP port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -9705,7 +9720,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9719,7 +9734,7 @@ Resource Types:
 
 
 
-
+Exec specifies the action to take.
 
 <table>
     <thead>
@@ -9734,7 +9749,7 @@ Resource Types:
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9746,7 +9761,7 @@ Resource Types:
 
 
 
-
+GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
 
 <table>
     <thead>
@@ -9761,7 +9776,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Port number of the gRPC service. Number must be in the range 1 to 65535.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -9770,7 +9785,8 @@ Resource Types:
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
+ If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9782,7 +9798,7 @@ Resource Types:
 
 
 
-
+HTTPGet specifies the http request to perform.
 
 <table>
     <thead>
@@ -9797,35 +9813,35 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecinitcontainersindexstartupprobehttpgethttpheadersindex">httpHeaders</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Custom headers to set in the request. HTTP allows repeated headers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path to access on the HTTP server.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9837,7 +9853,7 @@ Resource Types:
 
 
 
-
+HTTPHeader describes a custom header to be used in HTTP probes
 
 <table>
     <thead>
@@ -9852,14 +9868,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The header field value<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -9871,7 +9887,7 @@ Resource Types:
 
 
 
-
+TCPSocket specifies an action involving a TCP port.
 
 <table>
     <thead>
@@ -9886,14 +9902,14 @@ Resource Types:
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Optional: Host name to connect to, defaults to the pod IP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9905,7 +9921,7 @@ Resource Types:
 
 
 
-
+volumeDevice describes a mapping of a raw block device within a container.
 
 <table>
     <thead>
@@ -9920,14 +9936,14 @@ Resource Types:
         <td><b>devicePath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          devicePath is the path inside of the container that the device will be mapped to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          name must match the name of a persistentVolumeClaim in the pod<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -9939,7 +9955,7 @@ Resource Types:
 
 
 
-
+VolumeMount describes a mounting of a Volume within a container.
 
 <table>
     <thead>
@@ -9954,42 +9970,42 @@ Resource Types:
         <td><b>mountPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path within the container at which the volume should be mounted.  Must not contain ':'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          This must match the Name of a Volume.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mountPropagation</b></td>
         <td>string</td>
         <td>
-          <br/>
+          mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPathExpr</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10001,7 +10017,9 @@ Resource Types:
 
 
 
-
+Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. 
+ If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions 
+ If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
 
 <table>
     <thead>
@@ -10016,7 +10034,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -10028,7 +10046,7 @@ Resource Types:
 
 
 
-
+PodReadinessGate contains the reference to a pod condition
 
 <table>
     <thead>
@@ -10043,7 +10061,7 @@ Resource Types:
         <td><b>conditionType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          ConditionType refers to a condition in the pod's condition list with matching type.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -10055,7 +10073,7 @@ Resource Types:
 
 
 
-
+SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.
 
 <table>
     <thead>
@@ -10070,7 +10088,9 @@ Resource Types:
         <td><b>fsGroup</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 
+ 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- 
+ If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -10079,14 +10099,14 @@ Resource Types:
         <td><b>fsGroupChangePolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -10095,14 +10115,14 @@ Resource Types:
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -10111,35 +10131,35 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>supplementalGroups</b></td>
         <td>[]integer</td>
         <td>
-          <br/>
+          A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecsecuritycontextsysctlsindex">sysctls</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10151,7 +10171,7 @@ Resource Types:
 
 
 
-
+The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -10166,28 +10186,28 @@ Resource Types:
         <td><b>level</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Level is SELinux level label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>role</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Role is a SELinux role label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Type is a SELinux type label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          <br/>
+          User is a SELinux user label that applies to the container.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10199,7 +10219,7 @@ Resource Types:
 
 
 
-
+The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -10214,14 +10234,15 @@ Resource Types:
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          type indicates which kind of seccomp profile will be applied. Valid options are: 
+ Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          <br/>
+          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10233,7 +10254,7 @@ Resource Types:
 
 
 
-
+Sysctl defines a kernel parameter to be set
 
 <table>
     <thead>
@@ -10248,14 +10269,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of a property to set<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Value of a property to set<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -10267,7 +10288,7 @@ Resource Types:
 
 
 
-
+The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -10282,28 +10303,28 @@ Resource Types:
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>gmsaCredentialSpecName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          GMSACredentialSpecName is the name of the GMSA credential spec to use.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10315,7 +10336,7 @@ Resource Types:
 
 
 
-
+The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
 
 <table>
     <thead>
@@ -10330,28 +10351,28 @@ Resource Types:
         <td><b>effect</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tolerationSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -10360,7 +10381,7 @@ Resource Types:
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10372,7 +10393,7 @@ Resource Types:
 
 
 
-
+TopologySpreadConstraint specifies how to spread matching pods among the given topology.
 
 <table>
     <thead>
@@ -10387,7 +10408,7 @@ Resource Types:
         <td><b>maxSkew</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10396,35 +10417,37 @@ Resource Types:
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          <br/>
+          TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>whenUnsatisfiable</b></td>
         <td>string</td>
         <td>
-          <br/>
+          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespectopologyspreadconstraintsindexlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>minDomains</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. 
+ For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. 
+ This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10433,14 +10456,16 @@ Resource Types:
         <td><b>nodeAffinityPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. 
+ If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>nodeTaintsPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. 
+ If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10452,7 +10477,7 @@ Resource Types:
 
 
 
-
+LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
 
 <table>
     <thead>
@@ -10467,14 +10492,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespectopologyspreadconstraintsindexlabelselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10486,7 +10511,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -10501,21 +10526,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10527,7 +10552,7 @@ Resource Types:
 
 
 
-
+Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
 <table>
     <thead>
@@ -10542,210 +10567,214 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexawselasticblockstore">awsElasticBlockStore</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexazuredisk">azureDisk</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexazurefile">azureFile</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          azureFile represents an Azure File Service mount on the host and bind mount to the pod.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexcephfs">cephfs</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          cephFS represents a Ceph FS mount on the host that shares a pod's lifetime<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexcinder">cinder</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexconfigmap">configMap</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          configMap represents a configMap that should populate this volume<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexcsi">csi</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexdownwardapi">downwardAPI</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          downwardAPI represents downward API about the pod that should populate this volume<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexemptydir">emptyDir</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeral">ephemeral</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. 
+ Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). 
+ Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. 
+ Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. 
+ A pod can use both types of ephemeral volumes and persistent volumes at the same time.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexfc">fc</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexflexvolume">flexVolume</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexflocker">flocker</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexgcepersistentdisk">gcePersistentDisk</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexgitrepo">gitRepo</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexglusterfs">glusterfs</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexhostpath">hostPath</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexiscsi">iscsi</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexnfs">nfs</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexpersistentvolumeclaim">persistentVolumeClaim</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexphotonpersistentdisk">photonPersistentDisk</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexportworxvolume">portworxVolume</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          portworxVolume represents a portworx volume attached and mounted on kubelets host machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojected">projected</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          projected items for all in one resources secrets, configmaps, and downward API<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexquobyte">quobyte</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          quobyte represents a Quobyte mount on the host that shares a pod's lifetime<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexrbd">rbd</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexscaleio">scaleIO</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexsecret">secret</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexstorageos">storageos</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexvspherevolume">vsphereVolume</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10757,7 +10786,7 @@ Resource Types:
 
 
 
-
+awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 
 <table>
     <thead>
@@ -10772,21 +10801,21 @@ Resource Types:
         <td><b>volumeID</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>partition</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10795,7 +10824,7 @@ Resource Types:
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10807,7 +10836,7 @@ Resource Types:
 
 
 
-
+azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
 
 <table>
     <thead>
@@ -10822,42 +10851,42 @@ Resource Types:
         <td><b>diskName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          diskName is the Name of the data disk in the blob storage<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>diskURI</b></td>
         <td>string</td>
         <td>
-          <br/>
+          diskURI is the URI of data disk in the blob storage<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>cachingMode</b></td>
         <td>string</td>
         <td>
-          <br/>
+          cachingMode is the Host Caching mode: None, Read Only, Read Write.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10869,7 +10898,7 @@ Resource Types:
 
 
 
-
+azureFile represents an Azure File Service mount on the host and bind mount to the pod.
 
 <table>
     <thead>
@@ -10884,21 +10913,21 @@ Resource Types:
         <td><b>secretName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          secretName is the  name of secret that contains Azure Storage Account Name and Key<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>shareName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          shareName is the azure share Name<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10910,7 +10939,7 @@ Resource Types:
 
 
 
-
+cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
 
 <table>
     <thead>
@@ -10925,42 +10954,42 @@ Resource Types:
         <td><b>monitors</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>secretFile</b></td>
         <td>string</td>
         <td>
-          <br/>
+          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexcephfssecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          <br/>
+          user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10972,7 +11001,7 @@ Resource Types:
 
 
 
-
+secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <table>
     <thead>
@@ -10987,7 +11016,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10999,7 +11028,7 @@ Resource Types:
 
 
 
-
+cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 
 <table>
     <thead>
@@ -11014,28 +11043,28 @@ Resource Types:
         <td><b>volumeID</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexcindersecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11047,7 +11076,7 @@ Resource Types:
 
 
 
-
+secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.
 
 <table>
     <thead>
@@ -11062,7 +11091,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11074,7 +11103,7 @@ Resource Types:
 
 
 
-
+configMap represents a configMap that should populate this volume
 
 <table>
     <thead>
@@ -11089,7 +11118,7 @@ Resource Types:
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11098,21 +11127,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexconfigmapitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          optional specify whether the ConfigMap or its keys must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11124,7 +11153,7 @@ Resource Types:
 
 
 
-
+Maps a string key to a path within a volume.
 
 <table>
     <thead>
@@ -11139,21 +11168,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the key to project.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11167,7 +11196,7 @@ Resource Types:
 
 
 
-
+csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
 
 <table>
     <thead>
@@ -11182,35 +11211,35 @@ Resource Types:
         <td><b>driver</b></td>
         <td>string</td>
         <td>
-          <br/>
+          driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexcsinodepublishsecretref">nodePublishSecretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeAttributes</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11222,7 +11251,7 @@ Resource Types:
 
 
 
-
+nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
 
 <table>
     <thead>
@@ -11237,7 +11266,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11249,7 +11278,7 @@ Resource Types:
 
 
 
-
+downwardAPI represents downward API about the pod that should populate this volume
 
 <table>
     <thead>
@@ -11264,7 +11293,7 @@ Resource Types:
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11273,7 +11302,7 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexdownwardapiitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Items is a list of downward API volume file<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11285,7 +11314,7 @@ Resource Types:
 
 
 
-
+DownwardAPIVolumeFile represents information to create the file containing the pod field
 
 <table>
     <thead>
@@ -11300,21 +11329,21 @@ Resource Types:
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexdownwardapiitemsindexfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11323,7 +11352,7 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexdownwardapiitemsindexresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11335,7 +11364,7 @@ Resource Types:
 
 
 
-
+Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
 
 <table>
     <thead>
@@ -11350,14 +11379,14 @@ Resource Types:
         <td><b>fieldPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path of the field to select in the specified API version.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiVersion</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Version of the schema the FieldPath is written in terms of, defaults to "v1".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11369,7 +11398,7 @@ Resource Types:
 
 
 
-
+Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
 
 <table>
     <thead>
@@ -11384,21 +11413,21 @@ Resource Types:
         <td><b>resource</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required: resource to select<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>containerName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container name: required for volumes, optional for env vars<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>divisor</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Specifies the output format of the exposed resources, defaults to "1"<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11410,7 +11439,7 @@ Resource Types:
 
 
 
-
+emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
 
 <table>
     <thead>
@@ -11425,14 +11454,14 @@ Resource Types:
         <td><b>medium</b></td>
         <td>string</td>
         <td>
-          <br/>
+          medium represents what type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>sizeLimit</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11444,7 +11473,11 @@ Resource Types:
 
 
 
-
+ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. 
+ Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). 
+ Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. 
+ Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. 
+ A pod can use both types of ephemeral volumes and persistent volumes at the same time.
 
 <table>
     <thead>
@@ -11459,7 +11492,10 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplate">volumeClaimTemplate</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). 
+ An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. 
+ This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. 
+ Required, must not be nil.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11471,7 +11507,10 @@ Resource Types:
 
 
 
-
+Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). 
+ An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. 
+ This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. 
+ Required, must not be nil.
 
 <table>
     <thead>
@@ -11486,14 +11525,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>metadata</b></td>
         <td>object</td>
         <td>
-          <br/>
+          May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11505,7 +11544,7 @@ Resource Types:
 
 
 
-
+The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
 
 <table>
     <thead>
@@ -11520,56 +11559,56 @@ Resource Types:
         <td><b>accessModes</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecdatasource">dataSource</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecresources">resources</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecselector">selector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          selector is a label query over volumes to consider for binding.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>storageClassName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeMode</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeName is the binding reference to the PersistentVolume backing this claim.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11581,7 +11620,7 @@ Resource Types:
 
 
 
-
+dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.
 
 <table>
     <thead>
@@ -11596,21 +11635,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Kind is the type of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          <br/>
+          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11622,7 +11661,7 @@ Resource Types:
 
 
 
-
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -11637,21 +11676,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Kind is the type of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          <br/>
+          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11663,7 +11702,7 @@ Resource Types:
 
 
 
-
+resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
 
 <table>
     <thead>
@@ -11678,14 +11717,14 @@ Resource Types:
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11697,7 +11736,7 @@ Resource Types:
 
 
 
-
+selector is a label query over volumes to consider for binding.
 
 <table>
     <thead>
@@ -11712,14 +11751,14 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11731,7 +11770,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -11746,21 +11785,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11772,7 +11811,7 @@ Resource Types:
 
 
 
-
+fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
 
 <table>
     <thead>
@@ -11787,14 +11826,14 @@ Resource Types:
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>lun</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          lun is Optional: FC target lun number<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11803,21 +11842,21 @@ Resource Types:
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>targetWWNs</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          targetWWNs is Optional: FC target worldwide names (WWNs)<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>wwids</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11829,7 +11868,7 @@ Resource Types:
 
 
 
-
+flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
 
 <table>
     <thead>
@@ -11844,35 +11883,35 @@ Resource Types:
         <td><b>driver</b></td>
         <td>string</td>
         <td>
-          <br/>
+          driver is the name of the driver to use for this volume.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>options</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          options is Optional: this field holds extra command options if any.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexflexvolumesecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11884,7 +11923,7 @@ Resource Types:
 
 
 
-
+secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
 
 <table>
     <thead>
@@ -11899,7 +11938,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11911,7 +11950,7 @@ Resource Types:
 
 
 
-
+flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
 
 <table>
     <thead>
@@ -11926,14 +11965,14 @@ Resource Types:
         <td><b>datasetName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>datasetUUID</b></td>
         <td>string</td>
         <td>
-          <br/>
+          datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11945,7 +11984,7 @@ Resource Types:
 
 
 
-
+gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
 <table>
     <thead>
@@ -11960,21 +11999,21 @@ Resource Types:
         <td><b>pdName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>partition</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11983,7 +12022,7 @@ Resource Types:
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11995,7 +12034,7 @@ Resource Types:
 
 
 
-
+gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
 
 <table>
     <thead>
@@ -12010,21 +12049,21 @@ Resource Types:
         <td><b>repository</b></td>
         <td>string</td>
         <td>
-          <br/>
+          repository is the URL<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>directory</b></td>
         <td>string</td>
         <td>
-          <br/>
+          directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>revision</b></td>
         <td>string</td>
         <td>
-          <br/>
+          revision is the commit hash for the specified revision.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12036,7 +12075,7 @@ Resource Types:
 
 
 
-
+glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md
 
 <table>
     <thead>
@@ -12051,21 +12090,21 @@ Resource Types:
         <td><b>endpoints</b></td>
         <td>string</td>
         <td>
-          <br/>
+          endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12077,7 +12116,7 @@ Resource Types:
 
 
 
-
+hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.
 
 <table>
     <thead>
@@ -12092,14 +12131,14 @@ Resource Types:
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12111,7 +12150,7 @@ Resource Types:
 
 
 
-
+iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
 
 <table>
     <thead>
@@ -12126,14 +12165,14 @@ Resource Types:
         <td><b>iqn</b></td>
         <td>string</td>
         <td>
-          <br/>
+          iqn is the target iSCSI Qualified Name.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>lun</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          lun represents iSCSI Target Lun number.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12142,63 +12181,63 @@ Resource Types:
         <td><b>targetPortal</b></td>
         <td>string</td>
         <td>
-          <br/>
+          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>chapAuthDiscovery</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>chapAuthSession</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          chapAuthSession defines whether support iSCSI Session CHAP authentication<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initiatorName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>iscsiInterface</b></td>
         <td>string</td>
         <td>
-          <br/>
+          iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>portals</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexiscsisecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secretRef is the CHAP Secret for iSCSI target and initiator authentication<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12210,7 +12249,7 @@ Resource Types:
 
 
 
-
+secretRef is the CHAP Secret for iSCSI target and initiator authentication
 
 <table>
     <thead>
@@ -12225,7 +12264,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12237,7 +12276,7 @@ Resource Types:
 
 
 
-
+nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 
 <table>
     <thead>
@@ -12252,21 +12291,21 @@ Resource Types:
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>server</b></td>
         <td>string</td>
         <td>
-          <br/>
+          server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12278,7 +12317,7 @@ Resource Types:
 
 
 
-
+persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 
 <table>
     <thead>
@@ -12293,14 +12332,14 @@ Resource Types:
         <td><b>claimName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly Will force the ReadOnly setting in VolumeMounts. Default false.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12312,7 +12351,7 @@ Resource Types:
 
 
 
-
+photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
 
 <table>
     <thead>
@@ -12327,14 +12366,14 @@ Resource Types:
         <td><b>pdID</b></td>
         <td>string</td>
         <td>
-          <br/>
+          pdID is the ID that identifies Photon Controller persistent disk<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12346,7 +12385,7 @@ Resource Types:
 
 
 
-
+portworxVolume represents a portworx volume attached and mounted on kubelets host machine
 
 <table>
     <thead>
@@ -12361,21 +12400,21 @@ Resource Types:
         <td><b>volumeID</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeID uniquely identifies a Portworx volume<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12387,7 +12426,7 @@ Resource Types:
 
 
 
-
+projected items for all in one resources secrets, configmaps, and downward API
 
 <table>
     <thead>
@@ -12402,7 +12441,7 @@ Resource Types:
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12411,7 +12450,7 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindex">sources</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          sources is the list of volume projections<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12423,7 +12462,7 @@ Resource Types:
 
 
 
-
+Projection that may be projected along with other supported volume types
 
 <table>
     <thead>
@@ -12438,28 +12477,28 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexconfigmap">configMap</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          configMap information about the configMap data to project<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexdownwardapi">downwardAPI</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          downwardAPI information about the downwardAPI data to project<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexsecret">secret</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secret information about the secret data to project<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexserviceaccounttoken">serviceAccountToken</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          serviceAccountToken is information about the serviceAccountToken data to project<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12471,7 +12510,7 @@ Resource Types:
 
 
 
-
+configMap information about the configMap data to project
 
 <table>
     <thead>
@@ -12486,21 +12525,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexconfigmapitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          optional specify whether the ConfigMap or its keys must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12512,7 +12551,7 @@ Resource Types:
 
 
 
-
+Maps a string key to a path within a volume.
 
 <table>
     <thead>
@@ -12527,21 +12566,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the key to project.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12555,7 +12594,7 @@ Resource Types:
 
 
 
-
+downwardAPI information about the downwardAPI data to project
 
 <table>
     <thead>
@@ -12570,7 +12609,7 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexdownwardapiitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          Items is a list of DownwardAPIVolume file<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12582,7 +12621,7 @@ Resource Types:
 
 
 
-
+DownwardAPIVolumeFile represents information to create the file containing the pod field
 
 <table>
     <thead>
@@ -12597,21 +12636,21 @@ Resource Types:
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexdownwardapiitemsindexfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12620,7 +12659,7 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexdownwardapiitemsindexresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12632,7 +12671,7 @@ Resource Types:
 
 
 
-
+Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
 
 <table>
     <thead>
@@ -12647,14 +12686,14 @@ Resource Types:
         <td><b>fieldPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path of the field to select in the specified API version.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiVersion</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Version of the schema the FieldPath is written in terms of, defaults to "v1".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12666,7 +12705,7 @@ Resource Types:
 
 
 
-
+Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
 
 <table>
     <thead>
@@ -12681,21 +12720,21 @@ Resource Types:
         <td><b>resource</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Required: resource to select<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>containerName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Container name: required for volumes, optional for env vars<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>divisor</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Specifies the output format of the exposed resources, defaults to "1"<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12707,7 +12746,7 @@ Resource Types:
 
 
 
-
+secret information about the secret data to project
 
 <table>
     <thead>
@@ -12722,21 +12761,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexsecretitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          optional field specify whether the Secret or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12748,7 +12787,7 @@ Resource Types:
 
 
 
-
+Maps a string key to a path within a volume.
 
 <table>
     <thead>
@@ -12763,21 +12802,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the key to project.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12791,7 +12830,7 @@ Resource Types:
 
 
 
-
+serviceAccountToken is information about the serviceAccountToken data to project
 
 <table>
     <thead>
@@ -12806,21 +12845,21 @@ Resource Types:
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path is the path relative to the mount point of the file to project the token into.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>audience</b></td>
         <td>string</td>
         <td>
-          <br/>
+          audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>expirationSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -12834,7 +12873,7 @@ Resource Types:
 
 
 
-
+quobyte represents a Quobyte mount on the host that shares a pod's lifetime
 
 <table>
     <thead>
@@ -12849,42 +12888,42 @@ Resource Types:
         <td><b>registry</b></td>
         <td>string</td>
         <td>
-          <br/>
+          registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>volume</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volume is a string that references an already created Quobyte volume by name.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>group</b></td>
         <td>string</td>
         <td>
-          <br/>
+          group to map volume access to Default is no group<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tenant</b></td>
         <td>string</td>
         <td>
-          <br/>
+          tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          <br/>
+          user to map volume access to Defaults to serivceaccount user<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12896,7 +12935,7 @@ Resource Types:
 
 
 
-
+rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
 
 <table>
     <thead>
@@ -12911,56 +12950,56 @@ Resource Types:
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          <br/>
+          image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>monitors</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>keyring</b></td>
         <td>string</td>
         <td>
-          <br/>
+          keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>pool</b></td>
         <td>string</td>
         <td>
-          <br/>
+          pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexrbdsecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          <br/>
+          user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12972,7 +13011,7 @@ Resource Types:
 
 
 
-
+secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 
 <table>
     <thead>
@@ -12987,7 +13026,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12999,7 +13038,7 @@ Resource Types:
 
 
 
-
+scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
 
 <table>
     <thead>
@@ -13014,70 +13053,70 @@ Resource Types:
         <td><b>gateway</b></td>
         <td>string</td>
         <td>
-          <br/>
+          gateway is the host address of the ScaleIO API Gateway.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexscaleiosecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>system</b></td>
         <td>string</td>
         <td>
-          <br/>
+          system is the name of the storage system as configured in ScaleIO.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>protectionDomain</b></td>
         <td>string</td>
         <td>
-          <br/>
+          protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>sslEnabled</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          sslEnabled Flag enable/disable SSL communication with Gateway, default false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>storageMode</b></td>
         <td>string</td>
         <td>
-          <br/>
+          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>storagePool</b></td>
         <td>string</td>
         <td>
-          <br/>
+          storagePool is the ScaleIO Storage Pool associated with the protection domain.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13089,7 +13128,7 @@ Resource Types:
 
 
 
-
+secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
 
 <table>
     <thead>
@@ -13104,7 +13143,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13116,7 +13155,7 @@ Resource Types:
 
 
 
-
+secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
 
 <table>
     <thead>
@@ -13131,7 +13170,7 @@ Resource Types:
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -13140,21 +13179,21 @@ Resource Types:
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexsecretitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          optional field specify whether the Secret or its keys must be defined<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>secretName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13166,7 +13205,7 @@ Resource Types:
 
 
 
-
+Maps a string key to a path within a volume.
 
 <table>
     <thead>
@@ -13181,21 +13220,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the key to project.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -13209,7 +13248,7 @@ Resource Types:
 
 
 
-
+storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
 
 <table>
     <thead>
@@ -13224,35 +13263,35 @@ Resource Types:
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecdeploymentspectemplatespecvolumesindexstorageossecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeNamespace</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13264,7 +13303,7 @@ Resource Types:
 
 
 
-
+secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
 
 <table>
     <thead>
@@ -13279,7 +13318,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13291,7 +13330,7 @@ Resource Types:
 
 
 
-
+vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
 
 <table>
     <thead>
@@ -13306,28 +13345,28 @@ Resource Types:
         <td><b>volumePath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          volumePath is the path that identifies vSphere volume vmdk<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>storagePolicyID</b></td>
         <td>string</td>
         <td>
-          <br/>
+          storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>storagePolicyName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          storagePolicyName is the storage Policy Based Management (SPBM) profile name.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13339,7 +13378,7 @@ Resource Types:
 
 
 
-
+External enables you to configure external grafana instances that is not managed by the operator.
 
 <table>
     <thead>
@@ -13354,28 +13393,28 @@ Resource Types:
         <td><b>url</b></td>
         <td>string</td>
         <td>
-          <br/>
+          URL of the external grafana instance you want to manage.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecexternaladminpassword">adminPassword</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          AdminPassword key to talk to the external grafana instance.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecexternaladminuser">adminUser</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          AdminUser key to talk to the external grafana instance.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecexternalapikey">apiKey</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          The API key to talk to the external grafana instance, you need to define ether apiKey or adminUser/adminPassword.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13387,7 +13426,7 @@ Resource Types:
 
 
 
-
+AdminPassword key to talk to the external grafana instance.
 
 <table>
     <thead>
@@ -13402,21 +13441,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key of the secret to select from.  Must be a valid secret key.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13428,7 +13467,7 @@ Resource Types:
 
 
 
-
+AdminUser key to talk to the external grafana instance.
 
 <table>
     <thead>
@@ -13443,21 +13482,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key of the secret to select from.  Must be a valid secret key.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13469,7 +13508,7 @@ Resource Types:
 
 
 
-
+The API key to talk to the external grafana instance, you need to define ether apiKey or adminUser/adminPassword.
 
 <table>
     <thead>
@@ -13484,21 +13523,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The key of the secret to select from.  Must be a valid secret key.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Specify whether the Secret or its key must be defined<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13510,7 +13549,7 @@ Resource Types:
 
 
 
-
+Ingress sets how the ingress object should look like with your grafana instance.
 
 <table>
     <thead>
@@ -13525,14 +13564,14 @@ Resource Types:
         <td><b><a href="grafanaspecingressmetadata">metadata</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          IngressSpec describes the Ingress the user wishes to exist.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13544,7 +13583,7 @@ Resource Types:
 
 
 
-
+ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).
 
 <table>
     <thead>
@@ -13578,7 +13617,7 @@ Resource Types:
 
 
 
-
+IngressSpec describes the Ingress the user wishes to exist.
 
 <table>
     <thead>
@@ -13593,28 +13632,28 @@ Resource Types:
         <td><b><a href="grafanaspecingressspecdefaultbackend">defaultBackend</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          DefaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ingressClassName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          IngressClassName is the name of an IngressClass cluster resource. Ingress controller implementations use this field to know whether they should be serving this Ingress resource, by a transitive connection (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class` annotation (simple constant name) was never formally defined, it was widely supported by Ingress controllers to create a direct binding between Ingress controller and Ingress resources. Newly created Ingress resources should prefer using the field. However, even though the annotation is officially deprecated, for backwards compatibility reasons, ingress controllers should still honor that annotation if present.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspecrulesindex">rules</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspectlsindex">tls</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13626,7 +13665,7 @@ Resource Types:
 
 
 
-
+DefaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.
 
 <table>
     <thead>
@@ -13641,14 +13680,14 @@ Resource Types:
         <td><b><a href="grafanaspecingressspecdefaultbackendresource">resource</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspecdefaultbackendservice">service</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13660,7 +13699,7 @@ Resource Types:
 
 
 
-
+Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
 
 <table>
     <thead>
@@ -13675,21 +13714,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Kind is the type of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          <br/>
+          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13701,7 +13740,7 @@ Resource Types:
 
 
 
-
+Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".
 
 <table>
     <thead>
@@ -13716,14 +13755,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the referenced service. The service must exist in the same namespace as the Ingress object.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspecdefaultbackendserviceport">port</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Port of the referenced service. A port name or port number is required for a IngressServiceBackend.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13735,7 +13774,7 @@ Resource Types:
 
 
 
-
+Port of the referenced service. A port name or port number is required for a IngressServiceBackend.
 
 <table>
     <thead>
@@ -13750,14 +13789,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of the port on the Service. This is a mutually exclusive setting with "Number".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>number</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -13771,7 +13810,7 @@ Resource Types:
 
 
 
-
+IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
 
 <table>
     <thead>
@@ -13786,14 +13825,15 @@ Resource Types:
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the IP in the Spec of the parent Ingress. 2. The `:` delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue. 
+ Host can be "precise" which is a domain name without the terminating dot of a network host (e.g. "foo.bar.com") or "wildcard", which is a domain name prefixed with a single wildcard label (e.g. "*.foo.com"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == "*"). Requests will be matched against the Host field in the following way: 1. If Host is precise, the request matches this rule if the http host header is equal to Host. 2. If Host is a wildcard, then the request matches this rule if the http host header is to equal to the suffix (removing the first label) of the wildcard rule.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspecrulesindexhttp">http</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13805,7 +13845,7 @@ Resource Types:
 
 
 
-
+HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
 
 <table>
     <thead>
@@ -13820,7 +13860,7 @@ Resource Types:
         <td><b><a href="grafanaspecingressspecrulesindexhttppathsindex">paths</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          A collection of paths that map requests to backends.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -13832,7 +13872,7 @@ Resource Types:
 
 
 
-
+HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
 
 <table>
     <thead>
@@ -13847,21 +13887,21 @@ Resource Types:
         <td><b><a href="grafanaspecingressspecrulesindexhttppathsindexbackend">backend</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Backend defines the referenced service endpoint to which the traffic will be forwarded to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>pathType</b></td>
         <td>string</td>
         <td>
-          <br/>
+          PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is done on a path element by element basis. A path element refers is the list of labels in the path split by the '/' separator. A request is a match for path p if every p is an element-wise prefix of p of the request path. Note that if the last element of the path is a substring of the last element in request path, it is not a match (e.g. /foo/bar matches /foo/bar/baz, but does not match /foo/barbaz). * ImplementationSpecific: Interpretation of the Path matching is up to the IngressClass. Implementations can treat this as a separate PathType or treat it identically to Prefix or Exact path types. Implementations are required to support all path types.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/' and must be present when using PathType with value "Exact" or "Prefix".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13873,7 +13913,7 @@ Resource Types:
 
 
 
-
+Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 <table>
     <thead>
@@ -13888,14 +13928,14 @@ Resource Types:
         <td><b><a href="grafanaspecingressspecrulesindexhttppathsindexbackendresource">resource</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspecrulesindexhttppathsindexbackendservice">service</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13907,7 +13947,7 @@ Resource Types:
 
 
 
-
+Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
 
 <table>
     <thead>
@@ -13922,21 +13962,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Kind is the type of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          <br/>
+          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13948,7 +13988,7 @@ Resource Types:
 
 
 
-
+Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".
 
 <table>
     <thead>
@@ -13963,14 +14003,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the referenced service. The service must exist in the same namespace as the Ingress object.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="grafanaspecingressspecrulesindexhttppathsindexbackendserviceport">port</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          Port of the referenced service. A port name or port number is required for a IngressServiceBackend.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13982,7 +14022,7 @@ Resource Types:
 
 
 
-
+Port of the referenced service. A port name or port number is required for a IngressServiceBackend.
 
 <table>
     <thead>
@@ -13997,14 +14037,14 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of the port on the Service. This is a mutually exclusive setting with "Number".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>number</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          Number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14018,7 +14058,7 @@ Resource Types:
 
 
 
-
+IngressTLS describes the transport layer security associated with an Ingress.
 
 <table>
     <thead>
@@ -14033,14 +14073,14 @@ Resource Types:
         <td><b>hosts</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>secretName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          SecretName is the name of the secret used to terminate TLS traffic on port 443. Field is left optional to allow TLS routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14067,7 +14107,7 @@ Resource Types:
         <td><b><a href="grafanaspecjsonnetlibrarylabelselector">libraryLabelSelector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14079,7 +14119,7 @@ Resource Types:
 
 
 
-
+A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
 
 <table>
     <thead>
@@ -14094,14 +14134,14 @@ Resource Types:
         <td><b><a href="grafanaspecjsonnetlibrarylabelselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14113,7 +14153,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -14128,21 +14168,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14154,7 +14194,7 @@ Resource Types:
 
 
 
-
+PersistentVolumeClaim creates a PVC if you need to attach one to your grafana instance.
 
 <table>
     <thead>
@@ -14169,7 +14209,7 @@ Resource Types:
         <td><b><a href="grafanaspecpersistentvolumeclaimmetadata">metadata</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14188,7 +14228,7 @@ Resource Types:
 
 
 
-
+ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).
 
 <table>
     <thead>
@@ -14244,28 +14284,28 @@ Resource Types:
         <td><b><a href="grafanaspecpersistentvolumeclaimspecdatasource">dataSource</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecpersistentvolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecpersistentvolumeclaimspecresources">resources</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ResourceRequirements describes the compute resource requirements.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecpersistentvolumeclaimspecselector">selector</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14279,14 +14319,14 @@ Resource Types:
         <td><b>volumeMode</b></td>
         <td>string</td>
         <td>
-          <br/>
+          PersistentVolumeMode describes how a volume is intended to be consumed, either Block or Filesystem.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          VolumeName is the binding reference to the PersistentVolume backing this claim.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14298,7 +14338,7 @@ Resource Types:
 
 
 
-
+TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -14313,21 +14353,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Kind is the type of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          <br/>
+          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14339,7 +14379,7 @@ Resource Types:
 
 
 
-
+TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -14354,21 +14394,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Kind is the type of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name is the name of resource being referenced<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          <br/>
+          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14380,7 +14420,7 @@ Resource Types:
 
 
 
-
+ResourceRequirements describes the compute resource requirements.
 
 <table>
     <thead>
@@ -14395,14 +14435,14 @@ Resource Types:
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          <br/>
+          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14414,7 +14454,7 @@ Resource Types:
 
 
 
-
+A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
 
 <table>
     <thead>
@@ -14429,14 +14469,14 @@ Resource Types:
         <td><b><a href="grafanaspecpersistentvolumeclaimspecselectormatchexpressionsindex">matchExpressions</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14448,7 +14488,7 @@ Resource Types:
 
 
 
-
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
 
 <table>
     <thead>
@@ -14463,21 +14503,21 @@ Resource Types:
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key is the label key that the selector applies to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          <br/>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14489,7 +14529,7 @@ Resource Types:
 
 
 
-
+Route sets how the ingress object should look like with your grafana instance, this only works in Openshift.
 
 <table>
     <thead>
@@ -14504,7 +14544,7 @@ Resource Types:
         <td><b><a href="grafanaspecroutemetadata">metadata</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14523,7 +14563,7 @@ Resource Types:
 
 
 
-
+ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).
 
 <table>
     <thead>
@@ -14593,28 +14633,28 @@ Resource Types:
         <td><b><a href="grafanaspecroutespecport">port</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          RoutePort defines a port mapping from a router to an endpoint in the service endpoints.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecroutespectls">tls</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          TLSConfig defines config used to secure a route and provide termination<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecroutespecto">to</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>wildcardPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          WildcardPolicyType indicates the type of wildcard support needed by routes.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14626,7 +14666,7 @@ Resource Types:
 
 
 
-
+RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.
 
 <table>
     <thead>
@@ -14641,21 +14681,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The kind of target that the route is referring to. Currently, only 'Service' is allowed<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          name of the service/target that is being referred to. e.g. name of the service<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14669,7 +14709,7 @@ Resource Types:
 
 
 
-
+RoutePort defines a port mapping from a router to an endpoint in the service endpoints.
 
 <table>
     <thead>
@@ -14684,7 +14724,7 @@ Resource Types:
         <td><b>targetPort</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          The target port on pods selected by the service this route points to. If this is a string, it will be looked up as a named port in the target endpoints port list. Required<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -14696,7 +14736,7 @@ Resource Types:
 
 
 
-
+TLSConfig defines config used to secure a route and provide termination
 
 <table>
     <thead>
@@ -14711,42 +14751,43 @@ Resource Types:
         <td><b>termination</b></td>
         <td>string</td>
         <td>
-          <br/>
+          termination indicates termination type.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>caCertificate</b></td>
         <td>string</td>
         <td>
-          <br/>
+          caCertificate provides the cert authority certificate contents<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>certificate</b></td>
         <td>string</td>
         <td>
-          <br/>
+          certificate provides certificate contents<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>destinationCACertificate</b></td>
         <td>string</td>
         <td>
-          <br/>
+          destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>insecureEdgeTerminationPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. 
+ * Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          <br/>
+          key provides key file contents<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14758,7 +14799,7 @@ Resource Types:
 
 
 
-
+RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.
 
 <table>
     <thead>
@@ -14773,21 +14814,21 @@ Resource Types:
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The kind of target that the route is referring to. Currently, only 'Service' is allowed<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          name of the service/target that is being referred to. e.g. name of the service<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14801,7 +14842,7 @@ Resource Types:
 
 
 
-
+Service sets how the service object should look like with your grafana instance, contains a number of defaults.
 
 <table>
     <thead>
@@ -14816,14 +14857,14 @@ Resource Types:
         <td><b><a href="grafanaspecservicemetadata">metadata</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecservicespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ServiceSpec describes the attributes that a user creates on a service.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14835,7 +14876,7 @@ Resource Types:
 
 
 
-
+ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).
 
 <table>
     <thead>
@@ -14869,7 +14910,7 @@ Resource Types:
 
 
 
-
+ServiceSpec describes the attributes that a user creates on a service.
 
 <table>
     <thead>
@@ -14884,49 +14925,50 @@ Resource Types:
         <td><b>allocateLoadBalancerNodePorts</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>clusterIP</b></td>
         <td>string</td>
         <td>
-          <br/>
+          clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>clusterIPs</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. 
+ This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>externalIPs</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>externalName</b></td>
         <td>string</td>
         <td>
-          <br/>
+          externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>externalTrafficPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>healthCheckNodePort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14935,84 +14977,85 @@ Resource Types:
         <td><b>internalTrafficPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ipFamilies</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName. 
+ This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ipFamilyPolicy</b></td>
         <td>string</td>
         <td>
-          <br/>
+          IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>loadBalancerClass</b></td>
         <td>string</td>
         <td>
-          <br/>
+          loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>loadBalancerIP</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>loadBalancerSourceRanges</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecservicespecportsindex">ports</a></b></td>
         <td>[]object</td>
         <td>
-          <br/>
+          The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>publishNotReadyAddresses</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>selector</b></td>
         <td>map[string]string</td>
         <td>
-          <br/>
+          Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>sessionAffinity</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="grafanaspecservicespecsessionaffinityconfig">sessionAffinityConfig</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          sessionAffinityConfig contains the configurations of session affinity.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          <br/>
+          type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15024,7 +15067,7 @@ Resource Types:
 
 
 
-
+ServicePort contains information on service's port.
 
 <table>
     <thead>
@@ -15039,7 +15082,7 @@ Resource Types:
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The port that will be exposed by this service.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -15048,21 +15091,21 @@ Resource Types:
         <td><b>appProtocol</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>nodePort</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -15071,7 +15114,7 @@ Resource Types:
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          <br/>
+          The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -15080,7 +15123,7 @@ Resource Types:
         <td><b>targetPort</b></td>
         <td>int or string</td>
         <td>
-          <br/>
+          Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15092,7 +15135,7 @@ Resource Types:
 
 
 
-
+sessionAffinityConfig contains the configurations of session affinity.
 
 <table>
     <thead>
@@ -15107,7 +15150,7 @@ Resource Types:
         <td><b><a href="grafanaspecservicespecsessionaffinityconfigclientip">clientIP</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          clientIP contains the configurations of Client IP based session affinity.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15119,7 +15162,7 @@ Resource Types:
 
 
 
-
+clientIP contains the configurations of Client IP based session affinity.
 
 <table>
     <thead>
@@ -15134,7 +15177,7 @@ Resource Types:
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          <br/>
+          timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -15148,7 +15191,7 @@ Resource Types:
 
 
 
-
+ServiceAccount sets how the ServiceAccount object should look like with your grafana instance, contains a number of defaults.
 
 <table>
     <thead>
@@ -15177,7 +15220,7 @@ Resource Types:
         <td><b><a href="grafanaspecserviceaccountmetadata">metadata</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15196,7 +15239,7 @@ Resource Types:
 
 
 
-
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -15211,7 +15254,7 @@ Resource Types:
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15223,7 +15266,7 @@ Resource Types:
 
 
 
-
+ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).
 
 <table>
     <thead>
@@ -15257,7 +15300,8 @@ Resource Types:
 
 
 
-
+ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. 
+ Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
 
 <table>
     <thead>
@@ -15272,49 +15316,49 @@ Resource Types:
         <td><b>apiVersion</b></td>
         <td>string</td>
         <td>
-          <br/>
+          API version of the referent.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>fieldPath</b></td>
         <td>string</td>
         <td>
-          <br/>
+          If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespace</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>resourceVersion</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>uid</b></td>
         <td>string</td>
         <td>
-          <br/>
+          UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15326,7 +15370,7 @@ Resource Types:
 
 
 
-
+GrafanaStatus defines the observed state of Grafana
 
 <table>
     <thead>


### PR DESCRIPTION
Adding explanation to the grafana CRDs to make the operator usage clearer.
I also update the `make api-docs` command to point on the more detailed CRD definition.
This definition enables our online documentation to become more detailed.

Sadly these docs won't be shown in the k8s api, due to how big the grafana crd is due to all the default resources.
So for example 

``` shell
k explain grafana.spec.config 
KIND:     Grafana
VERSION:  grafana.integreatly.org/v1beta1

DESCRIPTION:
     <empty>
```

Will keep on looking like this even after my change.