### PR TITLE
fix: don't use hardcoded cluster domain

### DIFF
--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -48,7 +48,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 
 	// try to assign the admin url
 	if !cr.PreferIngress() {
-		status.AdminUrl = fmt.Sprintf("%v://%v.%v.svc.cluster.local:%d", getGrafanaServerProtocol(cr), service.Name, cr.Namespace,
+		status.AdminUrl = fmt.Sprintf("%v://%v.%v:%d", getGrafanaServerProtocol(cr), service.Name, cr.Namespace,
 			int32(GetGrafanaPort(cr)))
 	}
 

--- a/docs/blog/v5-getting-started.md
+++ b/docs/blog/v5-getting-started.md
@@ -278,7 +278,7 @@ Should show you something like this
 
 ```yaml
 status:
-  adminUrl: http://grafana-ingress-service.default.svc.cluster.local:3000
+  adminUrl: http://grafana-ingress-service.default:3000
   dashboards:
   - default/grafanadashboard-sample-ingress/6eaed1ab-0b0a-4d7f-bc46-0e3c1f58c8a8
   stage: complete

--- a/tests/e2e/example-test/00-assert.yaml
+++ b/tests/e2e/example-test/00-assert.yaml
@@ -3,7 +3,7 @@ kind: Grafana
 metadata:
   name: grafana
 status:
-  adminUrl: http://grafana-service.grafana-operator-system.svc.cluster.local:3000
+  adminUrl: http://grafana-service.grafana-operator-system:3000
   stage: complete
   stageStatus: success
 ---


### PR DESCRIPTION
When calling grafana by service name, we don't have to rely on FQDN. The change reintroduces a fix similar to #791.

Fixes: #959