### PR TITLE
fix: [helm] service not selecting endpoints

### DIFF
--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.kubeRbacProxy.service.port }}
-              name: https
+              name: metrics
               protocol: TCP
           {{- with .Values.kubeRbacProxy.livenessProbe }}
           livenessProbe:

--- a/deploy/helm/grafana-operator/templates/service.yaml
+++ b/deploy/helm/grafana-operator/templates/service.yaml
@@ -8,8 +8,8 @@ spec:
   type: {{ .Values.kubeRbacProxy.service.type }}
   ports:
     - port: {{ .Values.kubeRbacProxy.service.port }}
-      targetPort: http
+      targetPort: metrics
       protocol: TCP
-      name: http
+      name: https
   selector:
     {{- include "grafana-operator.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Target port name must match the pod exposed port, if not the service won't select the endpoints.

gave port a name of metrics so it is clear as to what it is, setting the service port as https provides clarity as to the protocol to use on connection.

**Why change was required:** metrics service was not selecting the pod due to port names not matching. this prevented Prometheus from scraping the pods metrics.

These changes have been tested in a clean kind cluster with the service now selecting the operator pod.