### PR TITLE
Default value of WATCH_NAMESPACE when namespaceScope=true

### DIFF
--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -37,7 +37,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE
+              {{- if and .Values.namespaceScope (eq .Values.watchNamespaces "") }}
+              value: {{ .Release.Namespace }}
+              {{ else }}
               value: {{ .Values.watchNamespaces }}
+              {{- end }}
           args:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080


### PR DESCRIPTION
Set default value of WATCH_NAMESPACE to installation namespace if namespaceScope is set.

Closes #1005 