### PR TITLE
fix: allow labels to be overridden in the deployment pod template metadata

### DIFF
--- a/api/v1beta1/typeoverrides.go
+++ b/api/v1beta1/typeoverrides.go
@@ -80,7 +80,7 @@ type DeploymentV1PodTemplateSpec struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Specification of the desired behavior of the pod.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -117,6 +117,15 @@ spec:
                       template:
                         properties:
                           metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
                             type: object
                           spec:
                             properties:

--- a/config/grafana.integreatly.org_grafanas.yaml
+++ b/config/grafana.integreatly.org_grafanas.yaml
@@ -198,6 +198,15 @@ spec:
                           metadata:
                             description: 'Standard object''s metadata. More info:
                               https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
                             type: object
                           spec:
                             description: 'Specification of the desired behavior of

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
@@ -117,6 +117,15 @@ spec:
                       template:
                         properties:
                           metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
                             type: object
                           spec:
                             properties:

--- a/examples/pod_template_labels/README.md
+++ b/examples/pod_template_labels/README.md
@@ -1,0 +1,8 @@
+---
+title: "Pod template overrides example"
+linkTitle: "Pod template overrides example"
+---
+
+Shows how the Grafana pod metadata and spec can be overridden.
+
+{{< readfile file="resources.yaml" code="true" lang="yaml" >}}

--- a/examples/pod_template_labels/resources.yaml
+++ b/examples/pod_template_labels/resources.yaml
@@ -1,0 +1,21 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: "grafana"
+spec:
+  deployment:
+    spec:
+      template:
+        metadata:
+          labels:
+            pod_label_key: "pod_label_value"
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret


### PR DESCRIPTION
fixes #958 