### PR TITLE
feat: example for k3s/k3d using the built in ingress controller

### DIFF
--- a/examples/k3d/README.md
+++ b/examples/k3d/README.md
@@ -1,0 +1,8 @@
+---
+title: "k3d example"
+linkTitle: "k3d example"
+---
+
+A basic deployment of Grafana in k3d/k3d making use of the built-in Ingress controller.
+
+{{< readfile file="resources.yaml" code="true" lang="yaml" >}}

--- a/examples/k3d/resources.yaml
+++ b/examples/k3d/resources.yaml
@@ -1,0 +1,27 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: "grafana"
+spec:
+  ingress:
+    spec:
+      rules:
+        - http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: grafana-service
+                    port:
+                      number: 3000
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret


### PR DESCRIPTION
A small example that creates a working Ingress when deployed on k3s/k3d.