### PR TITLE
feat: do not create route until spec is provided

### DIFF
--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -78,6 +78,10 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Gr
 }
 
 func (r *IngressReconciler) reconcileRoute(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+	if cr.Spec.Route == nil || cr.Spec.Route.Spec == nil {
+		return v1beta1.OperatorStageResultSuccess, nil
+	}
+
 	route := model.GetGrafanaRoute(cr, scheme)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, route, func() error {

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -1,0 +1,8 @@
+---
+title: "OpenShift example"
+linkTitle: "OpenShift example"
+---
+
+A basic deployment that makes use of OpenShift routes.
+
+{{< readfile file="resources.yaml" code="true" lang="yaml" >}}

--- a/examples/openshift/resources.yaml
+++ b/examples/openshift/resources.yaml
@@ -1,0 +1,20 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: "grafana"
+spec:
+  # An empty route spec is enough to signal the creation of a default
+  # route to the operator. This can also be used to override defaults
+  # in the route spec.
+  route:
+    spec: {}
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret


### PR DESCRIPTION
This makes the behaviour of routes similar to that of Ingress. An empty route spec in the CR is enough to trigger the creation of the route.