### PR TITLE
fix: ignore folder title case in dashboard controller

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -480,7 +480,7 @@ func (r *GrafanaDashboardReconciler) GetFolderID(client *grapi.Client,
 	}
 
 	for _, folder := range folders {
-		if folder.Title == cr.Spec.FolderTitle {
+		if strings.EqualFold(folder.Title, cr.Spec.FolderTitle) {
 			return folder.ID, nil
 		}
 		continue


### PR DESCRIPTION
Grafana uses case-insensitive names for folders, so we should ignore case differences in dashboard controller.

NOTE: We had a similar fix for v4 a while ago: https://github.com/grafana-operator/grafana-operator/pull/830
