### PR TITLE
fix: crash due to nil labelSelector

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -13,6 +13,10 @@ import (
 )
 
 func GetMatchingInstances(ctx context.Context, k8sClient client.Client, labelSelector *v1.LabelSelector) (v1beta1.GrafanaList, error) {
+	if labelSelector == nil {
+		return v1beta1.GrafanaList{}, nil
+	}
+
 	var list v1beta1.GrafanaList
 	opts := []client.ListOption{
 		client.MatchingLabels(labelSelector.MatchLabels),


### PR DESCRIPTION
This PR should prevent operator from crashing due to nil dereference when CRs are created without label selectors.