### PR TITLE
Simplify folder controller schema, change folder uid if needed

### DIFF
--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -28,7 +28,8 @@ import (
 
 // GrafanaFolderSpec defines the desired state of GrafanaFolder
 type GrafanaFolderSpec struct {
-	Json string `json:"json,omitempty"`
+	// +optional
+	Title string `json:"title,omitempty"`
 
 	// selects Grafanas for import
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector"`
@@ -83,7 +84,7 @@ func (in *GrafanaFolderList) Find(namespace string, name string) *GrafanaFolder 
 
 func (in *GrafanaFolder) Hash() string {
 	hash := sha256.New()
-	hash.Write([]byte(in.Spec.Json))
+	hash.Write([]byte(in.Spec.Title))
 	return fmt.Sprintf("%x", hash.Sum(nil))
 }
 
@@ -96,4 +97,12 @@ func (in *GrafanaFolder) IsAllowCrossNamespaceImport() bool {
 		return *in.Spec.AllowCrossNamespaceImport
 	}
 	return false
+}
+
+func (in *GrafanaFolder) GetTitle() string {
+	if in.Spec.Title != "" {
+		return in.Spec.Title
+	}
+
+	return in.Name
 }

--- a/api/v1beta1/grafanafolder_types_test.go
+++ b/api/v1beta1/grafanafolder_types_test.go
@@ -1,0 +1,41 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGrafanaFolder_GetTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   GrafanaFolder
+		want string
+	}{
+		{
+			name: "No custom title",
+			cr: GrafanaFolder{
+				ObjectMeta: metav1.ObjectMeta{Name: "cr-name"},
+			},
+			want: "cr-name",
+		},
+		{
+			name: "Custom title",
+			cr: GrafanaFolder{
+				ObjectMeta: metav1.ObjectMeta{Name: "cr-name"},
+				Spec: GrafanaFolderSpec{
+					Title: "custom-title",
+				},
+			},
+			want: "custom-title",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cr.GetTitle()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/bundle/manifests/grafana.integreatly.org_grafanafolders.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanafolders.yaml
@@ -52,7 +52,7 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              json:
+              title:
                 type: string
             required:
             - instanceSelector

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -53,7 +53,7 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              json:
+              title:
                 type: string
             required:
             - instanceSelector

--- a/config/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/grafana.integreatly.org_grafanafolders.yaml
@@ -84,7 +84,7 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              json:
+              title:
                 type: string
             required:
             - instanceSelector

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -177,6 +177,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	controllerLog.Info("found matching Grafana instances for folder", "count", len(instances.Items))
 
+	success := true
 	for _, grafana := range instances.Items {
 		// check if this is a cross namespace import
 		if grafana.Namespace != folder.Namespace && !folder.IsAllowCrossNamespaceImport() {
@@ -192,7 +193,12 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		err = r.onFolderCreated(ctx, &grafana, folder)
 		if err != nil {
 			controllerLog.Error(err, "error reconciling folder", "folder", folder.Name, "grafana", grafana.Name)
+			success = false
 		}
+	}
+
+	if !success {
+		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -270,10 +269,6 @@ func (r *GrafanaFolderReconciler) onFolderDeleted(ctx context.Context, namespace
 }
 
 func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *v1beta1.Grafana, cr *v1beta1.GrafanaFolder) error {
-	if cr.Spec.Json == "" {
-		return nil
-	}
-
 	grafanaClient, err := client2.NewGrafanaClient(ctx, r.Client, grafana)
 	if err != nil {
 		return err
@@ -287,16 +282,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 		return nil
 	}
 
-	var folderFromJson map[string]interface{}
-	err = json.Unmarshal([]byte(cr.Spec.Json), &folderFromJson)
-	if err != nil {
-		return err
-	}
-
-	title := fmt.Sprintf("%v", folderFromJson["title"])
-	if title == "" {
-		title = cr.Name
-	}
+	title := cr.GetTitle()
 
 	// folder exists, update only
 	if exists && !cr.Unchanged() {

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -292,6 +292,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 		// Add to status to cover cases:
 		// - operator have previously failed to update status
 		// - the folder was created outside of operator
+		// - the folder was created through dashboard controller
 		if found, _ := grafana.Status.Folders.Find(cr.Namespace, cr.Name); !found {
 			grafana.Status.Folders = grafana.Status.Folders.Add(cr.Namespace, cr.Name, uid)
 			err = r.Client.Status().Update(ctx, grafana)

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -53,7 +53,7 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              json:
+              title:
                 type: string
             required:
             - instanceSelector

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -423,7 +423,7 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              json:
+              title:
                 type: string
             required:
             - instanceSelector

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -903,7 +903,7 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>json</b></td>
+        <td><b>title</b></td>
         <td>string</td>
         <td>
           <br/>


### PR DESCRIPTION
Several improvements for folder controller:
- I think there isn't much need in offering raw json for folders. - Their API is very limited ([docs](https://grafana.com/docs/grafana/latest/developers/http_api/folder/#create-folder)), we can simplify operator's code (no need to care about errors in json + no need to decode it) and UX a bit by exposing custom `title` in a separate field.
- Requeue folder sync in case of errors;
- Reorganize `onFolderCreated` a bit to make room for further introduction of permissions (those will be in json);
- Replace folder `uid` if needed (e.g. folder was created outside of operator or through dashboard controller => exists with different uid).