### PR TITLE
Document need for access to namespaces with dashboardNamespaceSelector

### DIFF
--- a/deploy/cluster_roles/README.md
+++ b/deploy/cluster_roles/README.md
@@ -10,10 +10,20 @@ If specifying the `--scan-all`, `--namespaces`, `DASHBOARD_NAMESPACES_ALL="true"
 then the ServiceAccount that Grafana is running as needs view access to the GrafanaDashboard resources in other namespaces.
 To grant those permissions the following ClusterRole and ClusterRoleBinding need to be deployed.
 
-Create the `ClusterRole`
+When using the `dashboardNamespaceSelector` the ServiceAccount also needs to be able to access other namespaces in the cluster
+and you should use the second example below.
+Note that these two examples both create a ClusteRole called `grafana-operator` and only one of them should be used.
+
+Create the `ClusterRole` without access to namesapces
 
 ```shell
 kubectl create -f deploy/cluster_roles/cluster_role_grafana_operator.yaml
+```
+
+Create the `ClusterRole` with access to namespaces
+
+```shell
+kubectl create -f deploy/cluster_roles/cluster_role_grafana_operator_namespace_selector.yaml
 ```
 
 Create the `ClusterRoleBinding` for the `ServiceAccount/grafana-operator` in the given namespace

--- a/deploy/cluster_roles/cluster_role_grafana_operator_namespace_selector.yaml
+++ b/deploy/cluster_roles/cluster_role_grafana_operator_namespace_selector.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: grafana-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanadashboards
+      - grafanadatasources
+      - grafanadatasources/status
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch


### PR DESCRIPTION
Fixes https://github.com/grafana-operator/grafana-operator/issues/1010.

In order to dashboardNamespaceSelector the ServiceOperator needs to be able to read namespace resources.
This documents that requirement.