### PR TITLE
fix: error returned when WATCH_NAMESPACE is not defined

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"os/signal"
 	"strings"
@@ -47,6 +46,12 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
+const (
+	// watchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE which specifies the Namespace to watch.
+	// If empty or undefined, the operator will run in cluster scope.
+	watchNamespaceEnvVar = "WATCH_NAMESPACE"
+)
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -59,19 +64,6 @@ func init() {
 
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
-}
-
-func getWatchNamespace() (string, error) {
-	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
-	// which specifies the Namespace to watch.
-	// An empty value means the operator is running with cluster scope.
-	watchNamespaceEnvVar := "WATCH_NAMESPACE"
-
-	ns, found := os.LookupEnv(watchNamespaceEnvVar)
-	if !found {
-		return "", fmt.Errorf("%s isn't set", watchNamespaceEnvVar)
-	}
-	return ns, nil
 }
 
 func main() {
@@ -91,10 +83,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	watchNamespace, err := getWatchNamespace()
-	if err != nil {
-		setupLog.Error(err, "unable to get watch namespace, operator running in cluster scoped mode")
-	}
+	watchNamespace, _ := os.LookupEnv(watchNamespaceEnvVar)
 
 	controllerOptions := ctrl.Options{
 		Namespace:              watchNamespace,


### PR DESCRIPTION
The following error is shown when starting the operator without specifying `WATCH_NAMESPACE`
```
1.683727162524107e+09	ERROR	setup	unable to get watch namespace, operator running in cluster scoped mode	{"error": "WATCH_NAMESPACE isn't set"}
main.main
	/Users/jbriones/projects/github/grafana-operator/grafana-operator/main.go:96
runtime.main
	/Users/jbriones/.gvm/gos/go1.19.5/src/runtime/proc.go:250
1.6837271625242188e+09	INFO	setup	operator running in cluster scoped mode
```

An error should not be shown in the logs if this is undefined as this is an optional env var. If the value of this env var is an empty string or undefined, the following info log will be shown instead:
```
operator running in cluster scoped mode
```