### PR TITLE
feat: add support for raw folder permissions

### DIFF
--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -31,6 +31,10 @@ type GrafanaFolderSpec struct {
 	// +optional
 	Title string `json:"title,omitempty"`
 
+	// raw json with folder permissions
+	// +optional
+	Permissions string `json:"permissions,omitempty"`
+
 	// selects Grafanas for import
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector"`
 
@@ -85,6 +89,7 @@ func (in *GrafanaFolderList) Find(namespace string, name string) *GrafanaFolder 
 func (in *GrafanaFolder) Hash() string {
 	hash := sha256.New()
 	hash.Write([]byte(in.Spec.Title))
+	hash.Write([]byte(in.Spec.Permissions))
 	return fmt.Sprintf("%x", hash.Sum(nil))
 }
 

--- a/bundle/manifests/grafana.integreatly.org_grafanafolders.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanafolders.yaml
@@ -52,6 +52,8 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              permissions:
+                type: string
               title:
                 type: string
             required:

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -53,6 +53,8 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              permissions:
+                type: string
               title:
                 type: string
             required:

--- a/config/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/grafana.integreatly.org_grafanafolders.yaml
@@ -84,6 +84,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              permissions:
+                description: raw json with folder permissions
+                type: string
               title:
                 type: string
             required:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -53,6 +53,8 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              permissions:
+                type: string
               title:
                 type: string
             required:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -423,6 +423,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              permissions:
+                description: raw json with folder permissions
+                type: string
               title:
                 type: string
             required:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -903,6 +903,13 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>permissions</b></td>
+        <td>string</td>
+        <td>
+          raw json with folder permissions<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>title</b></td>
         <td>string</td>
         <td>

--- a/docs/docs/folder.md
+++ b/docs/docs/folder.md
@@ -9,4 +9,51 @@ In a standard scenario, a folder with default settings gets created through a `G
 
 If you need more control over folders (such as RBAC settings), it can be achieved through a `GrafanaFolder` CR.
 
+**NOTE:** When the operator starts managing a folder, it changes the folder's uid to `metadata.uid` of the respective `GrafanaFolder` CR. There's no way to change that.
+
 To view all configuration you can do within folders, look at our [API documentation](../api/#grafanafolderspec).
+
+## Folder with custom title
+
+```yaml
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: test-folder
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  # If title is not defined, the value will be taken from metadata.name
+  title: custom title
+```
+
+## Folder with custom permissions
+
+When `permissions` value is empty/absent, a folder is created with default permissions. In all other scenarios, a raw JSON is passed to Grafana API, and it's up to Grafana to interpret it.
+
+```yaml
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: test-folder
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  permissions: |
+    {
+      "items": [
+        {
+          "role": "Admin",
+          "permission": 4
+        },
+        {
+          "role": "Editor",
+          "permission": 2
+        }
+      ]
+    }
+```
+
+**NOTE:** When an empty JSON is passed (`permissions: "{}"`), the access is stripped for everyone except for Admin (default Grafana behaviour).

--- a/examples/folder/README.md
+++ b/examples/folder/README.md
@@ -1,0 +1,8 @@
+---
+title: "Folder with permissions"
+linkTitle: "Folder with permissions"
+---
+
+Shows how to create a folder with custom title and [permissions](https://grafana.com/docs/grafana/v8.4/http_api/folder_permissions/#update-permissions-for-a-folder).
+
+{{< readfile file="resources.yaml" code="true" lang="yaml" >}}

--- a/examples/folder/resources.yaml
+++ b/examples/folder/resources.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: "grafana"
+spec:
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: test-folder
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+
+  # If title is not defined, the value will be taken from metadata.name
+  title: custom title
+
+  # When permissions value is empty/absent, a folder is created with default permissions
+  # When empty JSON is passed ("{}"), the access is stripped for everyone except for Admin (default Grafana behaviour)
+  permissions: |
+    {
+      "items": [
+        {
+          "role": "Admin",
+          "permission": 4
+        },
+        {
+          "role": "Editor",
+          "permission": 2
+        }
+      ]
+    }


### PR DESCRIPTION
Added support for raw folder permissions (JSON).
If we ever add support for teams, we can implement something more complex.