### PR TITLE
fix: goroutine leak in grafana client #1040

### DIFF
--- a/controllers/client/round_tripper.go
+++ b/controllers/client/round_tripper.go
@@ -16,6 +16,8 @@ type instrumentedRoundTripper struct {
 
 func NewInstrumentedRoundTripper(relatedResource string, metric *prometheus.CounterVec) http.RoundTripper {
 	transport := &http.Transport{
+		DisableKeepAlives:   true,
+		MaxIdleConnsPerHost: -1,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true, //nolint
 		},


### PR DESCRIPTION
While troubleshooting #1040, I played with pprof and also looked at operator's metrics.

In a lab with 1 grafana instance and 27 dashboards (inline `json`, `resyncPeriod: 30s`), all `inuse_space` entries of pprof showed adequate memory consumption while metrics-server data was showing a constant increase in overall memory consumption. And it was interesting that both operator and grafana instances were affected at the same time.

I noticed that `go_goroutines` metric was increasing over time going to thousands, which didn't look right.
`goroutine` section of pprof showed that those thousands of goroutines were coming from http connections:

![profile002](https://github.com/grafana-operator/grafana-operator/assets/46579601/4b9e22f1-444c-40fb-9fce-22aded971a5f)

Then I found that we have a custom `Transport` for grafana client which was added to instrument http status metrics, and that implementation did not disable persistent connections unlike the standard `Transport` of the grafana client.

For now, I just added a couple of lines that disable persistent connections. Later, we should probably think of changing this part of the code to reuse the standard http client of the client library.

With those changes applied, in my setup, `go_goroutines` metrics stays at about 122 whereas previously I had seen the number going over 6000. The memory consumption of the operator stayed within 39-41 Mb instead of ever-growing (over 100).

Btw, our url fetcher uses the same transport, so I guess I'd see an even higher number of goroutines should my setup had url-based dashboards in place.

Closes: #1040 