### PR TITLE
doc: Set the version in helm README based in Chart.yaml

### DIFF
--- a/PREPARE_RELEASE.md
+++ b/PREPARE_RELEASE.md
@@ -2,6 +2,16 @@
 
 In this repo you will need to perform the following tasks manually
 
+## Documentation
+
+Currently our documentation needs to be updated in two spots.
+
+You need to change the version in [hugo/config.toml](hugo/config.toml).
+You also need to change the version for helm in [deploy/helm/grafana-operator/Chart.yaml](deploy/helm/grafana-operator/Chart.yaml).
+After that you need to run `make helm/docs` which will generate the changes to become visible on our homepage.
+
+## OLM
+
 There is a lot of information on what is needed to manage OLM [compatible operators](https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/creating-the-csv).
 
 - Update the `Makefile`

--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.0"
+appVersion: "v5.0.0-rc3"

--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v5.0.0-rc3"
+appVersion: "v5.0.0"

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -7,7 +7,7 @@ linkTitle: "Helm installation"
 
 [grafana-operator](https://github.com/grafana-operator/grafana-operator) for Kubernetes to manage Grafana instances and grafana resources.
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.0.0-rc3](https://img.shields.io/badge/AppVersion-v5.0.0--rc3-informational?style=flat-square)
 
 ## Installation
 

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -7,14 +7,14 @@ linkTitle: "Helm installation"
 
 [grafana-operator](https://github.com/grafana-operator/grafana-operator) for Kubernetes to manage Grafana instances and grafana resources.
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.0.0-rc3](https://img.shields.io/badge/AppVersion-v5.0.0--rc3-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.0.0](https://img.shields.io/badge/AppVersion-v5.0.0-informational?style=flat-square)
 
 ## Installation
 
 This is a OCI helm chart, helm started support OCI in version 3.8.0.
 
 ```shell
-helm upgrade -i grafana-operator oci://ghcr.io/grafana-operator/helm-charts/grafana-operator --version v5.0.0-rc3
+helm upgrade -i grafana-operator oci://ghcr.io/grafana-operator/helm-charts/grafana-operator --version v5.0.0
 ```
 
 Sadly helm OCI charts currently don't support searching for available versions of a helm [oci registry](https://github.com/helm/helm/issues/11000).

--- a/deploy/helm/grafana-operator/README.md.gotmpl
+++ b/deploy/helm/grafana-operator/README.md.gotmpl
@@ -14,7 +14,7 @@ linkTitle: "Helm installation"
 This is a OCI helm chart, helm started support OCI in version 3.8.0.
 
 ```shell
-helm upgrade -i grafana-operator oci://ghcr.io/grafana-operator/helm-charts/grafana-operator --version v5.0.0-rc3
+helm upgrade -i grafana-operator oci://ghcr.io/grafana-operator/helm-charts/grafana-operator --version {{ template "chart.appVersion" . }}
 ```
 
 Sadly helm OCI charts currently don't support searching for available versions of a helm [oci registry](https://github.com/helm/helm/issues/11000).


### PR DESCRIPTION
This allows version to be properly generated in `deploy/helm/grafana-operator/README.md` using https://github.com/norwoodj/helm-docs/tree/master/cmd/helm-docs