### PR TITLE
feat(dashboard): nullify hardcoded id

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -454,6 +454,10 @@ func (r *GrafanaDashboardReconciler) getDashboardModel(cr *v1beta1.GrafanaDashbo
 		return map[string]interface{}{}, "", err
 	}
 
+	// NOTE: id should never be hardcoded in a dashboard, otherwise grafana will try to update a dashboard by id instead of uid.
+	//       And, in case the id is non-existent, grafana will respond with 404. https://github.com/grafana-operator/grafana-operator/issues/1108
+	dashboardModel["id"] = nil
+
 	uid, _ := dashboardModel["uid"].(string) //nolint:errcheck
 	if uid == "" {
 		uid = string(cr.UID)


### PR DESCRIPTION
When `id` is hardcoded in a `GrafanaDashboard`, the operator is likely to fail to create the dashboard in a Grafana instance.
The PR makes sure `id` is nullified before dashboard model is passed to Grafana client.

(Strictly speaking, `id` should never be defined by a user in the first place, so it's more around improving UX.) 

## More details

Basically, when `id` is set, Grafana tries to update a dashboard by the `id`, not `uid`. And, expectedly, that can cause various issues, e.g. if the `id` is missing, Grafana responds with 404.

## Example of a failing CR

```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: grafanadashboard-sample
spec:
  resyncPeriod: 30s
  instanceSelector:
    matchLabels:
      dashboards: "grafana"
  json: >
    {
      "id": 146,
      "title": "Simple Dashboard",
      "tags": [],
      "style": "dark",
      "timezone": "browser",
      "editable": true,
      "hideControls": false,
      "graphTooltip": 1,
      "panels": [],
      "time": {
        "from": "now-6h",
        "to": "now"
      },
      "timepicker": {
        "time_options": [],
        "refresh_intervals": []
      },
      "templating": {
        "list": []
      },
      "annotations": {
        "list": []
      },
      "refresh": "5s",
      "schemaVersion": 17,
      "version": 0,
      "links": []
    }
```

Fixes: #1108 