### PR TITLE
chore: minor changes in workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,9 +65,6 @@ jobs:
         run: |
           kind create cluster --image=kindest/node:v1.25.3 --config tests/e2e/kind.yaml
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-
       - name: Build and load (current arch)
         env:
           KO_DOCKER_REPO: ko.local/grafana-operator/grafana-operator

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - uses: ko-build/setup-ko@v0.6
         with:
-          version: v0.13.0
+          version: v0.14.1
 
       - name: Prepare
         run: |
@@ -104,5 +104,4 @@ jobs:
             --image-label org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }} \
             --image-label org.opencontainers.image.revision=${{ github.sha }} \
             --image-label org.opencontainers.image.version=${{ github.ref_name }} \
-            --image-label org.opencontainers.image.created=${{ env.BUILD_DATE }} \
-            --insecure-registry
+            --image-label org.opencontainers.image.created=${{ env.BUILD_DATE }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-    - cron: "1 * * * *"
+    - cron: "0 1 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION
- `release-github`:
  - Bump `ko` to `v0.14.1`, which should potentially make our builds [faster](https://github.com/ko-build/ko/pull/1005);
  - Remove `--insecure-registry` `ko` flag. We added it early on as a workaround when there was a typo in ghcr name (=> certificate wasn't valid);
- `stale`:
  - Since `actions/stale` operates in dates, I think there isn't much value in running the workflow every hour. - Once a day should be enough;
- `e2e`:
  - Remove `docker/setup-buildx-action` step, because it's not needed for `ko`.