### PR TITLE
WIP: Allow split of watch namespaces

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -57,4 +57,6 @@ It's easier to just manage this configuration outside of the operator.
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | pod tolerations |
+| watchNamespaceCrdLabels | list | `[]` | Sets the WATCH_LABEL_CRD environment variables, it defines which namespaces the operator should be watching for dashboards, dataSources and folders by namespace label. |
+| watchNamespaceLabels | list | `[]` | Sets the WATCH_LABEL environment variables, it defines which namespaces the operator should be watching for by namespace label. |
 | watchNamespaces | string | `""` | Sets the WATCH_NAMESPACE environment variable, it defines which namespaces the operator should be listening for. By default it's all namespaces, if you only want to listen for the same namespace as the operator is deployed to look at namespaceScope. |

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -10,6 +10,12 @@ leaderElect: false
 # By default it's all namespaces, if you only want to listen for the same namespace as the operator is deployed to look at namespaceScope.
 watchNamespaces: ""
 
+# -- Sets the WATCH_LABEL and WATCH_LABEL_CRD environment variables,
+# it defines which namespaces the operator should be listening for by namespace label.
+# WATCH_LABEL_CRD is used for dashboards, dataSources and folders.
+watchNamespaceLabels: []
+watchNamespaceCrdLabels: []
+
 image:
   # -- grafana operator image repository
   repository: ghcr.io/grafana-operator/grafana-operator

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -10,10 +10,12 @@ leaderElect: false
 # By default it's all namespaces, if you only want to listen for the same namespace as the operator is deployed to look at namespaceScope.
 watchNamespaces: ""
 
-# -- Sets the WATCH_LABEL and WATCH_LABEL_CRD environment variables,
-# it defines which namespaces the operator should be listening for by namespace label.
-# WATCH_LABEL_CRD is used for dashboards, dataSources and folders.
+# -- Sets the WATCH_LABEL environment variables,
+# it defines which namespaces the operator should be watching for by namespace label.
 watchNamespaceLabels: []
+
+# -- Sets the WATCH_LABEL_CRD environment variables,
+# it defines which namespaces the operator should be watching for dashboards, dataSources and folders by namespace label.
 watchNamespaceCrdLabels: []
 
 image:

--- a/main.go
+++ b/main.go
@@ -19,10 +19,15 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
@@ -66,12 +71,59 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
+func getWatchNamespaceFromLabelsInEnv(watchLabelEnvVar string) (string, error) {
+	label, found := os.LookupEnv(watchLabelEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s isn't set", watchLabelEnvVar)
+	}
+
+	ns, err := getNamespacesWithLabel(label)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve the namespaces for a label: %s", err)
+	}
+
+	return ns, nil
+}
+
+func getNamespacesWithLabel(label string) (string, error) {
+	ctx := context.Background()
+	config := ctrl.GetConfigOrDie()
+	clientset := kubernetes.NewForConfigOrDie(config)
+
+	list, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return "", err
+	}
+
+	nsStrList := make([]string, 0)
+	for _, ns := range list.Items {
+		nsStrList = append(nsStrList, ns.Name)
+	}
+
+	return strings.Join(nsStrList, ","), nil
+}
+
+func getWatchNamespace() (string, error) {
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which specifies the Namespace to watch.
+	// An empty value means the operator is running with cluster scope.
+	ns, found := os.LookupEnv(watchNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s isn't set", watchNamespaceEnvVar)
+	}
+	return ns, nil
+}
+
 func main() {
 	var metricsAddr string
+	var metricsAddrCrd string
 	var enableLeaderElection bool
 	var probeAddr string
+	var probeAddrCrd string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddrCrd, "metrics-bind-address-crd", ":8082", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddrCrd, "health-probe-bind-address-crd", ":8084", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -83,7 +135,26 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	watchNamespace, _ := os.LookupEnv(watchNamespaceEnvVar)
+	// Get the namespaces to watch for all objects using the selector label
+	watchNamespace, err := getWatchNamespaceFromLabelsInEnv("WATCH_LABEL")
+	if err != nil {
+		setupLog.Error(err, "unable to get watch namespace from labels, operator running in cluster scoped mode")
+	}
+
+	// If we didn't get watchNamespace from label, check if it's specifically set
+	if watchNamespace == "" {
+		watchNamespace, err = getWatchNamespace()
+		if err != nil {
+			setupLog.Error(err, "unable to get watch namespace, operator running in cluster scoped mode")
+		}
+	}
+
+	// Get the namespaces to watch for CRD objects using the selector label
+	watchNamespaceCrd, err := getWatchNamespaceFromLabelsInEnv("WATCH_LABEL_CRD")
+	if err != nil {
+		setupLog.Error(err, "unable to get CRD watch namespace from labels, using generic namespace list")
+		watchNamespaceCrd = watchNamespace
+	}
 
 	controllerOptions := ctrl.Options{
 		Namespace:              watchNamespace,
@@ -94,7 +165,17 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "f75f3bba.integreatly.org",
 	}
+	controllerOptionsCrd := ctrl.Options{
+		Namespace:              watchNamespaceCrd,
+		Scheme:                 scheme,
+		MetricsBindAddress:     metricsAddrCrd,
+		Port:                   9443,
+		HealthProbeBindAddress: probeAddrCrd,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "f75f3bbb.integreatly.org",
+	}
 
+	// Prepare the controllerOptions
 	switch {
 	case strings.Contains(watchNamespace, ","):
 		// multi namespace scoped
@@ -109,12 +190,36 @@ func main() {
 		setupLog.Info("operator running in cluster scoped mode")
 	}
 
+	// Prepare the controllerOptionsCrd
+	switch {
+	case strings.Contains(watchNamespaceCrd, ","):
+		// multi namespace scoped
+		setupLog.Info("CRD manager set up with multiple namespaces", "namespaces", watchNamespaceCrd)
+		controllerOptionsCrd.Namespace = ""
+		controllerOptionsCrd.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNamespaceCrd, ","))
+	case watchNamespaceCrd != "":
+		// namespace scoped
+		setupLog.Info("CRD operator running in namespace scoped mode", "namespace", watchNamespaceCrd)
+		controllerOptionsCrd.Namespace = watchNamespaceCrd
+		controllerOptions.NewCache = cache.BuilderWithOptions(cache.Options{Namespace: watchNamespaceCrd})
+	case watchNamespaceCrd == "":
+		// cluster scoped
+		setupLog.Info("CRD operator running in cluster scoped mode")
+		controllerOptions.NewCache = cache.BuilderWithOptions(cache.Options{})
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
 	defer stop()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), controllerOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to create new manager")
+		os.Exit(1) //nolint
+	}
+
+	mgrCrd, err := ctrl.NewManager(ctrl.GetConfigOrDie(), controllerOptionsCrd)
+	if err != nil {
+		setupLog.Error(err, "unable to create new CRD manager")
 		os.Exit(1) //nolint
 	}
 
@@ -140,25 +245,25 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.GrafanaDashboardReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client: mgrCrd.GetClient(),
+		Scheme: mgrCrd.GetScheme(),
 		Log:    ctrl.Log.WithName("DashboardReconciler"),
-	}).SetupWithManager(mgr, ctx); err != nil {
+	}).SetupWithManager(mgrCrd, ctx); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaDashboard")
 		os.Exit(1)
 	}
 	if err = (&controllers.GrafanaDatasourceReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client: mgrCrd.GetClient(),
+		Scheme: mgrCrd.GetScheme(),
 		Log:    ctrl.Log.WithName("DatasourceReconciler"),
-	}).SetupWithManager(mgr, ctx); err != nil {
+	}).SetupWithManager(mgrCrd, ctx); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaDatasource")
 		os.Exit(1)
 	}
 	if err = (&controllers.GrafanaFolderReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, ctx); err != nil {
+		Client: mgrCrd.GetClient(),
+		Scheme: mgrCrd.GetScheme(),
+	}).SetupWithManager(mgrCrd, ctx); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaFolder")
 		os.Exit(1)
 	}
@@ -168,17 +273,34 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgrCrd.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
+	mgrCtx := ctrl.SetupSignalHandler()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		setupLog.Info("starting manager")
+		if err := mgr.Start(mgrCtx); err != nil {
+			setupLog.Error(err, "problem running manager")
+			os.Exit(1)
+		}
+		<-ctx.Done()
+		wg.Done()
+		setupLog.Info("SIGTERM request gotten, shutting down operator")
+	}()
+	go func() {
+		setupLog.Info("starting managerCrd")
+		if err := mgrCrd.Start(mgrCtx); err != nil {
+			setupLog.Error(err, "problem running managerCrd")
+			os.Exit(1)
+		}
+		<-ctx.Done()
+		wg.Done()
+		setupLog.Info("SIGTERM request gotten, shutting down operator")
+	}()
 
-	<-ctx.Done()
-	setupLog.Info("SIGTERM request gotten, shutting down operator")
+	wg.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func getWatchNamespaceFromLabelsInEnv(watchLabelEnvVar string) (string, error) {
 
 	ns, err := getNamespacesWithLabel(label)
 	if err != nil {
-		return "", fmt.Errorf("failed to retrieve the namespaces for a label: %s", err)
+		return "", fmt.Errorf("failed to retrieve the namespaces for a label: %w", err)
 	}
 
 	return ns, nil
@@ -220,7 +220,7 @@ func main() {
 	mgrCrd, err := ctrl.NewManager(ctrl.GetConfigOrDie(), controllerOptionsCrd)
 	if err != nil {
 		setupLog.Error(err, "unable to create new CRD manager")
-		os.Exit(1) //nolint
+		os.Exit(1)
 	}
 
 	restConfig := ctrl.GetConfigOrDie()


### PR DESCRIPTION
Allows split of namespaces, where Grafana CRDs are watched in namespace specified in $WATCH_NAMESPACE or from all namespaces with label $WATCH_LABEL and GrafanaDashboards, GrafanaFolders and GrafanaDatasources are watched in all namespaces with label $WATCH_LABEL_CRD.

Closes #1007

NOTE 1: I'm not really satisfied with how this PR turned out because there is now two ready-ness probe endpoints. Look at it as a start of a discussion.
NOTE 2: As I'm expecting a discussion with appropriate changes, I have not updated the helm chart to reflect these changes. The documentation needs to be updated as well.
NOTE 3: I've used the PR#1053 as base, which will be removed once that PR has been merged.