### PR TITLE
feat: allow cpu limit to be removed

### DIFF
--- a/controllers/reconcilers/grafana/deployment_reconciler_test.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler_test.go
@@ -1,0 +1,106 @@
+package grafana
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/grafana-operator/grafana-operator/v5/api/v1beta1"
+)
+
+func Test_getResources(t *testing.T) {
+	defaultRequests := v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse(MemoryRequest),
+		v1.ResourceCPU:    resource.MustParse(CpuRequest),
+	}
+
+	defaultLimits := v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse(MemoryLimit),
+		v1.ResourceCPU:    resource.MustParse(CpuLimit),
+	}
+
+	defaultLimitsWithoutCPU := v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse(MemoryLimit),
+	}
+
+	tests := []struct {
+		name string
+		cr   *v1beta1.Grafana
+		want v1.ResourceRequirements
+	}{
+		{
+			name: "Resources entirely not defined should return defaults",
+			cr:   &v1beta1.Grafana{},
+			want: v1.ResourceRequirements{
+				Requests: defaultRequests,
+				Limits:   defaultLimits,
+			},
+		},
+		{
+			name: "Resource Limits not defined should return defaults",
+			cr: &v1beta1.Grafana{
+				Spec: v1beta1.GrafanaSpec{
+					Deployment: &v1beta1.DeploymentV1{
+						Spec: v1beta1.DeploymentV1Spec{
+							Template: &v1beta1.DeploymentV1PodTemplateSpec{
+								Spec: &v1beta1.DeploymentV1PodSpec{
+									Containers: []v1.Container{
+										{
+											Name: "grafana",
+											Resources: v1.ResourceRequirements{
+												Requests: defaultRequests,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: v1.ResourceRequirements{
+				Requests: defaultRequests,
+				Limits:   defaultLimits,
+			},
+		},
+		{
+			name: "Only CPU Limit not defined should return default Requests and default Memory Limit",
+			cr: &v1beta1.Grafana{
+				Spec: v1beta1.GrafanaSpec{
+					Deployment: &v1beta1.DeploymentV1{
+						Spec: v1beta1.DeploymentV1Spec{
+							Template: &v1beta1.DeploymentV1PodTemplateSpec{
+								Spec: &v1beta1.DeploymentV1PodSpec{
+									Containers: []v1.Container{
+										{
+											Name: "grafana",
+											Resources: v1.ResourceRequirements{
+												Requests: defaultRequests,
+												Limits:   defaultLimitsWithoutCPU,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: v1.ResourceRequirements{
+				Requests: defaultRequests,
+				Limits:   defaultLimitsWithoutCPU,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := tt.want
+			got := getResources(tt.cr)
+
+			assert.Equal(t, want, got)
+		})
+	}
+}


### PR DESCRIPTION
Currently, CPU limit can't be removed. 

The [getResources](https://github.com/grafana-operator/grafana-operator/blob/v5.1.0/controllers/reconcilers/grafana/deployment_reconciler.go#L66) function, which creates the base for resources, sets the requests and limits for both memory and CPU. 

If one defines the container's limits not to include a CPU limit, the reconciler [merges](https://github.com/grafana-operator/grafana-operator/blob/v5.1.0/controllers/reconcilers/grafana/deployment_reconciler.go#L56) the base resources with the overrides defined in the CR using a [structural merge patch](https://github.com/grafana-operator/grafana-operator/blob/v5.0.2/api/v1beta1/typeoverrides.go#L384), which doesn't remove fields present in base but missing from the overrides. So, there's no way we can remove CPU limits.

Now, this should not be yet another discussion on whether we should or not specify CPU limits, but to allow those who need to remove CPU limits to do so.

Possible solutions:
- [Remove](https://github.com/grafana-operator/grafana-operator/blob/v5.1.0/controllers/reconcilers/grafana/deployment_reconciler.go#L74) the CPU limit from base: this is a breaking change, as users not defining the CPU limit would have to define it if needed. Also, having a CPU limit by default is a good thing if users don't want to explicitly remove it.

- Look for the grafana container defined in the CR and if the CR defines limits, but leaves out the CPU limit, don't add it to the base (ie. define the base with only a memory limit). This is not a breaking change because if users don't define limits, these will still be defined as they are now. The only change is, if the CR defines limits only containing a memory limit, then only the memory limit is set, not the CPU limit.

This is an implementation of the second solution, but I'm ok with implementing the first one.