### PR TITLE
feat: remove cpu limit default

### DIFF
--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -23,7 +23,6 @@ const (
 	MemoryRequest                           = "256Mi"
 	CpuRequest                              = "100m"
 	MemoryLimit                             = "1024Mi"
-	CpuLimit                                = "500m"
 	GrafanaHealthEndpoint                   = "/api/health"
 	ReadinessProbeFailureThreshold    int32 = 1
 	ReadinessProbeInitialDelaySeconds int32 = 5
@@ -71,7 +70,6 @@ func getResources() v1.ResourceRequirements {
 		},
 		Limits: v1.ResourceList{
 			v1.ResourceMemory: resource.MustParse(MemoryLimit),
-			v1.ResourceCPU:    resource.MustParse(CpuLimit),
 		},
 	}
 }


### PR DESCRIPTION
Currently, CPU limit can't be removed.

The [getResources](https://github.com/grafana-operator/grafana-operator/blob/v5.1.0/controllers/reconcilers/grafana/deployment_reconciler.go#L66) function, which creates the base for resources, sets the requests and limits for both memory and CPU.

If one defines the container's limits not to include a CPU limit, the reconciler [merges](https://github.com/grafana-operator/grafana-operator/blob/v5.1.0/controllers/reconcilers/grafana/deployment_reconciler.go#L56) the base resources with the overrides defined in the CR using a [structural merge patch](https://github.com/grafana-operator/grafana-operator/blob/v5.0.2/api/v1beta1/typeoverrides.go#L384), which doesn't remove fields present in base but missing from the overrides. So, there's no way we can remove CPU limits.

Now, this should not be yet another discussion on whether we should or not specify CPU limits, but to allow those who need to remove CPU limits to do so.

Possible solutions:

- [Remove](https://github.com/grafana-operator/grafana-operator/blob/v5.1.0/controllers/reconcilers/grafana/deployment_reconciler.go#L74) the CPU limit from base: this is a breaking change, as users not defining the CPU limit would have to define it if needed. Also, having a CPU limit by default is a good thing if users don't want to explicitly remove it.

- Look for the grafana container defined in the CR and if the CR defines limits, but leaves out the CPU limit, don't add it to the base (ie. define the base with only a memory limit). This is not a breaking change because if users don't define limits, these will still be defined as they are now. The only change is, if the CR defines limits only containing a memory limit, then only the memory limit is set, not the CPU limit.

This is an implementation of the first solution.

Related: https://github.com/grafana-operator/grafana-operator/pull/1161