### PR TITLE
fix: limit dashboard versions to 20 if not otherwise specified

### DIFF
--- a/controllers/config/grafana_ini.go
+++ b/controllers/config/grafana_ini.go
@@ -23,6 +23,14 @@ func WriteIni(cfg map[string]map[string]string) (string, string) {
 	cfg["paths"]["plugins"] = GrafanaPluginsPath
 	cfg["paths"]["provisioning"] = GrafanaProvisioningPath
 
+	if cfg["dashboards"] == nil {
+		cfg["dashboards"] = make(map[string]string)
+	}
+
+	if cfg["dashboards"]["versions_to_keep"] == "" {
+		cfg["dashboards"]["versions_to_keep"] = "20"
+	}
+
 	sections := make([]string, 0, len(cfg))
 	for key := range cfg {
 		sections = append(sections, key)


### PR DESCRIPTION
limit dashboard versions to 20 if not otherwise specified