### PR TITLE
feat: allow replacement pattern in data sources

### DIFF
--- a/examples/datasource_variables/README.md
+++ b/examples/datasource_variables/README.md
@@ -4,5 +4,26 @@ linkTitle: "Datasource variable"
 ---
 
 This example shows how to reference values from a secret in data source fields.
+Values can be assigned using `spec.valuesFrom`:
+
+```yaml
+  valuesFrom:
+    - targetPath: "secureJsonData.httpHeaderValue1"
+      valueFrom:
+        secretKeyRef:
+          name: "credentials"
+          key: "PROMETHEUS_TOKEN"
+```
+
+The Operator will look for a key with the name `PROMETHEUS_TOKEN` in a secret with the name `credentials`.
+It will then inject the value into `secureJsonData.httpHeaderValue1`:
+
+```yaml
+  datasource:
+    secureJsonData:
+      "httpHeaderValue1": "Bearer ${PROMETHEUS_TOKEN}"
+```
+
+The Operator expects a string to be present with the replacement pattern.
 
 {{< readfile file="resources.yaml" code="true" lang="yaml" >}}

--- a/examples/datasource_variables/resources.yaml
+++ b/examples/datasource_variables/resources.yaml
@@ -21,8 +21,7 @@ metadata:
   name: credentials
   namespace: grafana
 stringData:
-  PROMETHEUS_USERNAME: root
-  PROMETHEUS_PASSWORD: secret
+  PROMETHEUS_TOKEN: secret_token
 type: Opaque
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -31,16 +30,11 @@ metadata:
   name: grafanadatasource-sample
 spec:
   valuesFrom:
-    - targetPath: "user"
+    - targetPath: "secureJsonData.httpHeaderValue1"
       valueFrom:
         secretKeyRef:
           name: "credentials"
-          key: "PROMETHEUS_USERNAME"
-    - targetPath: "secureJsonData.password"
-      valueFrom:
-        secretKeyRef:
-          name: "credentials"
-          key: "PROMETHEUS_PASSWORD"
+          key: "PROMETHEUS_TOKEN"
   instanceSelector:
     matchLabels:
       dashboards: "grafana"
@@ -51,10 +45,10 @@ spec:
     basicAuth: true
     url: http://prometheus-service:9090
     isDefault: true
-    user: ${PROMETHEUS_USERNAME}
     jsonData:
       "tlsSkipVerify": true
       "timeInterval": "5s"
+      httpHeaderName1: 'Authorization'
     secureJsonData:
-      "password": ${PROMETHEUS_PASSWORD}
+      "httpHeaderValue1": "Bearer ${PROMETHEUS_TOKEN}"
     editable: true


### PR DESCRIPTION
# What

This PR extends the existing functionality to inject values from Secrets into data sources. It allows replacement patterns (e.g. `Bearer ${TOKEN}`) instead of overwriting whatever is there in the first place.

# Why

Injecting bearer tokens is a typical use case for data sources. However this was not properly supported until now. The value of a bearer token starts with `Bearer` followed by the token. The existing mechanism replaced the whole value, including the `Bearer` part. You would have to include `Bearer` in the secret, but often you don't create or manage those secrets.

# How

Bevor overwriting the value found at the given path, we fetch it and apply the replacement.