### PR TITLE
Fixed invalid value field in crd

### DIFF
--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -123,7 +123,7 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
-                    value:omitempty:
+                    value:
                       type: string
                   required:
                   - name


### PR DESCRIPTION
This CRD field was incorrectly defined, and would therefore prevent envs to be defined properly.