### PR TITLE
fix secretkeyref omitempty wrong symbol causing invalid crd field generation

### DIFF
--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -113,7 +113,7 @@ type GrafanaDashboardEnv struct {
 	Name string `json:"name"`
 	// Inline evn value
 	// +optional
-	Value string `json:"value:omitempty"`
+	Value string `json:"value,omitempty"`
 	// Selects a key of a ConfigMap.
 	// +optional
 	ConfigMapKeyRef *v1.ConfigMapKeySelector `json:"configMapKeyRef,omitempty"`

--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -123,7 +123,7 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
-                    value:omitempty:
+                    value:
                       type: string
                   required:
                   - name

--- a/config/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/grafana.integreatly.org_grafanadashboards.yaml
@@ -169,7 +169,7 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
-                    value:omitempty:
+                    value:
                       description: Inline evn value
                       type: string
                   required:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -123,7 +123,7 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
-                    value:omitempty:
+                    value:
                       type: string
                   required:
                   - name

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -168,7 +168,7 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
-                    value:omitempty:
+                    value:
                       description: Inline evn value
                       type: string
                   required:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -507,7 +507,7 @@ Selects a key of a Secret.
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>value:omitempty</b></td>
+        <td><b>value</b></td>
         <td>string</td>
         <td>
           Inline evn value<br/>


### PR DESCRIPTION
Fixes a wrong symbol used for tag splitting, this caused the field to be assigned the name of `value:omitempty`, rather than what the intent was, to assign the name `value` and add an omitempty call in the json tag. 
