### PR TITLE
add back subresource on OCP for custom hostname

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -162,6 +162,7 @@ rules:
   - route.openshift.io
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - create
   - delete

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -54,7 +54,7 @@ type GrafanaReconciler struct {
 //+kubebuilder:rbac:groups=grafana.integreatly.org,resources=grafanas,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=grafana.integreatly.org,resources=grafanas/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=grafana.integreatly.org,resources=grafanas/finalizers,verbs=update
-//+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;create;update;delete;watch
+//+kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;create;update;delete;watch
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="",resources=configmaps;secrets;serviceaccounts;services;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete

--- a/deploy/helm/grafana-operator/templates/rbac-clusterscope.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac-clusterscope.yaml
@@ -197,6 +197,7 @@ rules:
       - route.openshift.io
     resources:
       - routes
+      - routes/custom-host
     verbs:
       - create
       - delete

--- a/deploy/helm/grafana-operator/templates/rbac-namespace.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac-namespace.yaml
@@ -198,6 +198,7 @@ rules:
       - route.openshift.io
     resources:
       - routes
+      - routes/custom-host
     verbs:
       - create
       - delete

--- a/deploy/kustomize/overlays/cluster_scoped/rbac.yaml
+++ b/deploy/kustomize/overlays/cluster_scoped/rbac.yaml
@@ -193,6 +193,7 @@ rules:
       - route.openshift.io
     resources:
       - routes
+      - routes/custom-host
     verbs:
       - create
       - delete

--- a/deploy/kustomize/overlays/namespace_scoped/rbac.yaml
+++ b/deploy/kustomize/overlays/namespace_scoped/rbac.yaml
@@ -194,6 +194,7 @@ rules:
       - route.openshift.io
     resources:
       - routes
+      - routes/custom-host
     verbs:
       - create
       - delete


### PR DESCRIPTION
Fix for #1197 - add RBAC permission to route sub-resource on OCP.