### PR TITLE
extended operator resource memory limit

### DIFF
--- a/bundle/manifests/grafana-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/grafana-operator.clusterserviceversion.yaml
@@ -349,7 +349,7 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 100Mi
+                    memory: 256Mi
                   requests:
                     cpu: 100m
                     memory: 20Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 100Mi
+              memory: 256Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 100Mi
+              memory: 256Mi
             requests:
               cpu: 100m
               memory: 20Mi


### PR DESCRIPTION
OOM killed is encountered when running the operator on OpenShift environment. 
extending memory limits to 256Mi  