### PR TITLE
Increase grafana-operator-controller-manager memory limit

### DIFF
--- a/bundle/manifests/grafana-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/grafana-operator.clusterserviceversion.yaml
@@ -349,7 +349,7 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 256Mi
+                    memory: 550Mi
                   requests:
                     cpu: 100m
                     memory: 20Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 256Mi
+              memory: 550Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 550Mi
+              memory: 256Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 256Mi
+              memory: 550Mi
             requests:
               cpu: 100m
               memory: 20Mi


### PR DESCRIPTION
On OpenShift with 22 dashboards, the manager pod peaks around 465Mi at startup and then goes down to 250-270Mi. Increase the limit otherwise pod is dies with OOMKilled error.

Increase all 3 types of deployment for consistency reasons even though the referenced issue was for OLM.

Fixes #1255