### PR TITLE
helm chart: align labeling of rbac resources

### DIFF
--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -11,10 +11,11 @@ kind: {{ if not $namespaceScoped }}Cluster{{ end }}Role
 metadata:
   namespace: {{ . }}
   name: grafana-operator-permissions
-  {{- with (merge $.Values.additionalLabels (include "grafana-operator.labels" $ | fromYaml)) }}
-  labels:
+  labels: 
+    {{- include "grafana-operator.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -231,10 +232,11 @@ kind: {{ if not $namespaceScoped }}Cluster{{ end }}RoleBinding
 metadata:
   name: grafana-operator-permissions
   namespace: {{ . }}
-  {{- with (merge $.Values.additionalLabels (include "grafana-operator.labels" $ | fromYaml)) }}
   labels:
+    {{- include "grafana-operator.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "grafana-operator.serviceAccountName" $ }}


### PR DESCRIPTION
Hopefully fixes: https://github.com/grafana-operator/grafana-operator/issues/1298

This PR aligns the labels introduced by https://github.com/grafana-operator/grafana-operator/pull/1271 to the same code style as the other labels. I hope that this results in the above issue being fixed.