### PR TITLE
fix(proxy): don't use proxy for internal Grafana instances

### DIFF
--- a/controllers/client/grafana_client.go
+++ b/controllers/client/grafana_client.go
@@ -143,7 +143,7 @@ func NewGrafanaClient(ctx context.Context, c client.Client, grafana *v1beta1.Gra
 	clientConfig := grapi.Config{
 		HTTPHeaders: nil,
 		Client: &http.Client{
-			Transport: NewInstrumentedRoundTripper(grafana.Name, metrics.GrafanaApiRequests),
+			Transport: NewInstrumentedRoundTripper(grafana.Name, metrics.GrafanaApiRequests, grafana.IsExternal()),
 			Timeout:   time.Second * timeout,
 		},
 		// TODO populate me

--- a/controllers/client/round_tripper.go
+++ b/controllers/client/round_tripper.go
@@ -13,8 +13,14 @@ type instrumentedRoundTripper struct {
 	metric          *prometheus.CounterVec
 }
 
-func NewInstrumentedRoundTripper(relatedResource string, metric *prometheus.CounterVec) http.RoundTripper {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+func NewInstrumentedRoundTripper(relatedResource string, metric *prometheus.CounterVec, useProxy bool) http.RoundTripper {
+	transport := &http.Transport{}
+
+	// Default transport respects proxy settings
+	if useProxy {
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+
 	transport.DisableKeepAlives = true
 	transport.MaxIdleConnsPerHost = -1
 	transport.TLSClientConfig.InsecureSkipVerify = true //nolint

--- a/controllers/fetchers/grafana_com_fetcher.go
+++ b/controllers/fetchers/grafana_com_fetcher.go
@@ -42,7 +42,7 @@ func getLatestGrafanaComRevision(dashboard *v1beta1.GrafanaDashboard) (int, erro
 		return -1, err
 	}
 
-	client := client2.NewInstrumentedRoundTripper(fmt.Sprintf("%v/%v", dashboard.Namespace, dashboard.Name), metrics.GrafanaComApiRevisionRequests)
+	client := client2.NewInstrumentedRoundTripper(fmt.Sprintf("%v/%v", dashboard.Namespace, dashboard.Name), metrics.GrafanaComApiRevisionRequests, true)
 	response, err := client.RoundTrip(request)
 	if err != nil {
 		return -1, err

--- a/controllers/fetchers/url_fetcher.go
+++ b/controllers/fetchers/url_fetcher.go
@@ -30,7 +30,7 @@ func FetchDashboardFromUrl(dashboard *v1beta1.GrafanaDashboard) ([]byte, error) 
 		return nil, err
 	}
 
-	client := client2.NewInstrumentedRoundTripper(fmt.Sprintf("%v/%v", dashboard.Namespace, dashboard.Name), metrics.DashboardUrlRequests)
+	client := client2.NewInstrumentedRoundTripper(fmt.Sprintf("%v/%v", dashboard.Namespace, dashboard.Name), metrics.DashboardUrlRequests, true)
 	response, err := client.RoundTrip(request)
 	if err != nil {
 		return nil, err

--- a/docs/docs/_index.md
+++ b/docs/docs/_index.md
@@ -87,5 +87,5 @@ This is because especially the data sources contain secret information and we do
 
 ## Using a proxy server
 
-The Operator can use a proxy server when making requests to Grafana.
+The Operator can use a proxy server when fetching URL-based / Grafana.com dashboards or making requests to external Grafana instances.
 The proxy settings can be controlled through environment variables as documented [here](https://pkg.go.dev/golang.org/x/net/http/httpproxy#FromEnvironment).


### PR DESCRIPTION
As highlighted in #1295, it's not always easy to properly set `NO_PROXY` env to make sure requests to internal Grafana instances are not proxied.
Seems like it would make the most sense if we respect proxy settings only for external Grafana instances and for URL-based dashboards. Thus the PR.

Fixes: #1295