### PR TITLE
fix(client): tls transport nil dereference

### DIFF
--- a/controllers/client/round_tripper.go
+++ b/controllers/client/round_tripper.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"crypto/tls"
 	"net/http"
 	"strconv"
 
@@ -15,16 +14,15 @@ type instrumentedRoundTripper struct {
 }
 
 func NewInstrumentedRoundTripper(relatedResource string, metric *prometheus.CounterVec, useProxy bool) http.RoundTripper {
-	transport := &http.Transport{TLSClientConfig: &tls.Config{}}
-
-	// Default transport respects proxy settings
-	if useProxy {
-		transport = http.DefaultTransport.(*http.Transport).Clone()
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 
 	transport.DisableKeepAlives = true
 	transport.MaxIdleConnsPerHost = -1
 	transport.TLSClientConfig.InsecureSkipVerify = true //nolint
+
+	if !useProxy {
+		transport.Proxy = nil
+	}
 
 	return &instrumentedRoundTripper{
 		relatedResource: relatedResource,

--- a/controllers/client/round_tripper.go
+++ b/controllers/client/round_tripper.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"crypto/tls"
 	"net/http"
 	"strconv"
 
@@ -14,7 +15,7 @@ type instrumentedRoundTripper struct {
 }
 
 func NewInstrumentedRoundTripper(relatedResource string, metric *prometheus.CounterVec, useProxy bool) http.RoundTripper {
-	transport := &http.Transport{}
+	transport := &http.Transport{TLSClientConfig: &tls.Config{}}
 
 	// Default transport respects proxy settings
 	if useProxy {


### PR DESCRIPTION
That should fix nil deference for tls transport that was accidentaly introduced in #1300 