### PR TITLE
re-add containerImage to config manifests

### DIFF
--- a/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Monitoring
+    containerImage: ghcr.io/grafana-operator/grafana-operator:v5.5.0
     createdAt: "2023-09-12T08:09:00.92Z"
     repository: https://github.com/grafana-operator/grafana-operator
     support: Community


### PR DESCRIPTION
The current OLM instructions points that we should update `annotations.containerImage` but this resource currently doesn't exist.
It's needed for `make bundle/redhat` to be able to automatically generate the SHAs for OLM to work in disconnected mode. Without it, the upstream operator PRs don't pass basic tests. 