### PR TITLE
helm chart: fix broken default values

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -38,7 +38,6 @@ It's easier to just manage this configuration outside of the operator.
 | additionalLabels | object | `{}` | additional labels to add to all resources |
 | affinity | object | `{}` | pod affinity |
 | env | list | `[]` | Additional environment variables |
-| env.grafanaImage | string | `""` | grafana image, e.g. docker.io/grafana/grafana:9.1.6, overwrites the default grafana image defined in the operator |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in grafana operator container |
 | image.repository | string | `"ghcr.io/grafana-operator/grafana-operator"` | grafana operator image repository |

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -42,10 +42,6 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- if .Values.env.grafanaImage }}
-            - name: RELATED_IMAGE_GRAFANA
-              value: {{ .Values.env.grafanaImage }}
-            {{- end }}
             - name: WATCH_NAMESPACE
               {{- if and .Values.namespaceScope (eq .Values.watchNamespaces "") }}
               value: {{ .Release.Namespace }}

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -12,6 +12,9 @@ watchNamespaces: ""
 
 # -- Additional environment variables
 env: []
+  # -- grafana image, e.g. docker.io/grafana/grafana:9.1.6, overwrites the default grafana image defined in the operator
+  # - name: RELATED_IMAGE_GRAFANA
+  #   value: "docker.io/grafana/grafana:9.1.6"
   # - name: MY_VAR
   #   value: "myvalue"
 
@@ -25,10 +28,6 @@ image:
 
 # -- image pull secrets
 imagePullSecrets: []
-
-env:
-  # -- grafana image, e.g. docker.io/grafana/grafana:9.1.6, overwrites the default grafana image defined in the operator
-  grafanaImage: ""
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Fixes #1315, introduced in 3166d43.

Should be noted, that the current v5.5.0 helm chart is completely broken because of this. So a patch release might be necessary :) 