### PR TITLE
Run helm template as a basic check of the helm chart

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -133,6 +133,10 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      - name: Run helm-template
+        run: |
+          helm template deploy/helm/grafana-operator/
+
       - name: Run helm-docs
         run: |
           make helm/docs

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -137,6 +137,9 @@ jobs:
         run: |
           helm template deploy/helm/grafana-operator/
 
+      - name: Run helm-lint
+        run: |
+          helm lint deploy/helm/grafana-operator/
       - name: Run helm-docs
         run: |
           make helm/docs


### PR DESCRIPTION
As a part of a PR let's verify that the helm chart at least is possible to render the helm template command.
In the future we can add extra install steps to verify that it's possible to install and run some tests as well.
