### PR TITLE
fix(deployment reconciler): Couldn't parse image reference "docker.io/grafana/grafana@9.1.6"

### DIFF
--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -136,7 +136,7 @@ func getVolumeMounts(cr *v1beta1.Grafana, scheme *runtime.Scheme) []v1.VolumeMou
 func setGrafanaImage() string {
 	grafanaImg := os.Getenv("RELATED_IMAGE_GRAFANA")
 	if grafanaImg == "" {
-		grafanaImg = fmt.Sprintf("%s@%s", config2.GrafanaImage, config2.GrafanaVersion)
+		grafanaImg = fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
 	}
 	return grafanaImg
 }

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -133,7 +133,7 @@ func getVolumeMounts(cr *v1beta1.Grafana, scheme *runtime.Scheme) []v1.VolumeMou
 	return mounts
 }
 
-func setGrafanaImage() string {
+func getGrafanaImage() string {
 	grafanaImg := os.Getenv("RELATED_IMAGE_GRAFANA")
 	if grafanaImg == "" {
 		grafanaImg = fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
@@ -144,7 +144,7 @@ func setGrafanaImage() string {
 func getContainers(cr *v1beta1.Grafana, scheme *runtime.Scheme, vars *v1beta1.OperatorReconcileVars, openshiftPlatform bool) []v1.Container {
 	var containers []v1.Container
 
-	image := setGrafanaImage()
+	image := getGrafanaImage()
 	plugins := model.GetPluginsConfigMap(cr, scheme)
 
 	// env var to restart containers if plugins change

--- a/controllers/reconcilers/grafana/deployment_reconciler_test.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler_test.go
@@ -1,0 +1,23 @@
+package grafana
+
+import (
+	"fmt"
+	"testing"
+
+	config2 "github.com/grafana-operator/grafana-operator/v5/controllers/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_setGrafanaImage(t *testing.T) {
+	expectedDeploymentImage := fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
+
+	assert.Equal(t, expectedDeploymentImage, setGrafanaImage())
+}
+
+func Test_setGrafanaImage_withEnvironmentOverride(t *testing.T) {
+	expectedDeploymentImage := "I want this grafana image"
+	t.Setenv("RELATED_IMAGE_GRAFANA", expectedDeploymentImage)
+
+	assert.Equal(t, expectedDeploymentImage, setGrafanaImage())
+}

--- a/controllers/reconcilers/grafana/deployment_reconciler_test.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler_test.go
@@ -9,15 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_setGrafanaImage(t *testing.T) {
+func Test_getGrafanaImage(t *testing.T) {
 	expectedDeploymentImage := fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
 
-	assert.Equal(t, expectedDeploymentImage, setGrafanaImage())
+	assert.Equal(t, expectedDeploymentImage, getGrafanaImage())
 }
 
-func Test_setGrafanaImage_withEnvironmentOverride(t *testing.T) {
+func Test_getGrafanaImage_withEnvironmentOverride(t *testing.T) {
 	expectedDeploymentImage := "I want this grafana image"
 	t.Setenv("RELATED_IMAGE_GRAFANA", expectedDeploymentImage)
 
-	assert.Equal(t, expectedDeploymentImage, setGrafanaImage())
+	assert.Equal(t, expectedDeploymentImage, getGrafanaImage())
 }


### PR DESCRIPTION
### To Reproduce
1. Perform a basic helm deployment (flux in my case) of the grafana-operater. 
2. Create a sample `Grafana` and `GrafanaDashboard` resource. 

### Result 

The resultant `Deployment` artifact produces the following error:

```
Warning  InspectFailed  9s (x11 over 2m7s)  kubelet            Failed to apply default image tag "docker.io/grafana/grafana@9.1.6": couldn't parse image reference "docker.io/grafana/grafana@9.1.6": invalid reference format
Warning  Failed         9s (x11 over 2m7s)  kubelet            Error: InvalidImageName
```

After some checking, I found the cause related to a recent change made to the `deployment_reconciler.go` file. The issue seemed straightforward enough, so I made the fix and added some tests.

I have never done go before, so please accept my apologies if I made any mistakes.

Thank you for your consideration and review.
