### PR TITLE
Add namespace to templates

### DIFF
--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -7,7 +7,7 @@ linkTitle: "Helm installation"
 
 [grafana-operator](https://github.com/grafana-operator/grafana-operator) for Kubernetes to manage Grafana instances and grafana resources.
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.5.1](https://img.shields.io/badge/AppVersion-v5.5.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.5.1](https://img.shields.io/badge/AppVersion-v5.5.1-informational?style=flat-square)
 
 ## Installation
 

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -7,7 +7,7 @@ linkTitle: "Helm installation"
 
 [grafana-operator](https://github.com/grafana-operator/grafana-operator) for Kubernetes to manage Grafana instances and grafana resources.
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.5.1](https://img.shields.io/badge/AppVersion-v5.5.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.5.2](https://img.shields.io/badge/AppVersion-v5.5.2-informational?style=flat-square)
 
 ## Installation
 

--- a/deploy/helm/grafana-operator/templates/cm.yaml
+++ b/deploy/helm/grafana-operator/templates/cm.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "grafana-operator.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- with .Values.additionalLabels }}
     {{- toYaml . | nindent 4 }}

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "grafana-operator.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
     {{- with .Values.additionalLabels }}

--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -9,7 +9,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not $namespaceScoped }}Cluster{{ end }}Role
 metadata:
+  {{- if $namespaceScoped }}
+  namespace: {{ $operatorNamespace }}
+  {{- else }}
   namespace: {{ . }}
+  {{- end }}
   name: grafana-operator-permissions
   labels:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
@@ -231,7 +235,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not $namespaceScoped }}Cluster{{ end }}RoleBinding
 metadata:
   name: grafana-operator-permissions
+  {{- if $namespaceScoped }}
+  namespace: {{ $operatorNamespace }}
+  {{- else }}
   namespace: {{ . }}
+  {{- end }}
   labels:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
     {{- with $.Values.additionalLabels }}

--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -11,8 +11,6 @@ kind: {{ if not $namespaceScoped }}Cluster{{ end }}Role
 metadata:
   {{- if $namespaceScoped }}
   namespace: {{ $operatorNamespace }}
-  {{- else }}
-  namespace: {{ . }}
   {{- end }}
   name: grafana-operator-permissions
   labels:
@@ -237,8 +235,6 @@ metadata:
   name: grafana-operator-permissions
   {{- if $namespaceScoped }}
   namespace: {{ $operatorNamespace }}
-  {{- else }}
-  namespace: {{ . }}
   {{- end }}
   labels:
     {{- include "grafana-operator.labels" $ | nindent 4 }}

--- a/deploy/helm/grafana-operator/templates/service.yaml
+++ b/deploy/helm/grafana-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "grafana-operator.fullname" . }}-metrics-service
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
     {{- with .Values.additionalLabels }}

--- a/deploy/helm/grafana-operator/templates/serviceaccount.yaml
+++ b/deploy/helm/grafana-operator/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "grafana-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
     {{- with .Values.additionalLabels }}


### PR DESCRIPTION
Adding namespaces to templates in order to avoid having objects deployed to the `default` namespace in certain deployment scenarios. 